### PR TITLE
Add alpine draws to ice climbing checklist

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,7 +58,7 @@ function checkAnswer(event) {
         rock: rescue_gear.concat(["Harness", "Helmet", "Radios", "Rope", "Nuts", "Cams", "Alpine Draws", "Nut Tool", "Gear Sling", "Runners", "Quick Draws", "Chalk and Chalk Bag", "Rock Shoes", "Belay and Crack Gloves"]),
         glacier: glacier_gear,
         snow: ["Gaiters", "Blue Bag", "Crampons", "Ice Ax", "Helmet"],
-        ice: glacier_gear.concat(["Harness", "Helmet", "Ice Screws", "Radios", "Crampons", "Ice Tools"]),
+        ice: glacier_gear.concat(["Harness", "Helmet", "Ice Screws", "Radios", "Crampons", "Ice Tools", "Alpine Draws"]),
         girl: ["Sport Bra", "Pad / Tampon / Menstural Cup", "Pee Funnel"],
         bear: ["Bear Canister / Ursack", "Bear Spray"],
         ski: avy_gear.concat(["Crampons", "Helmet", "Ski Pack", "Ski Crampons", "Ski Boots", "Skis", "Poles", "Skins", "Skin Wax", "Snow Pants", "Gloves", "Goggles", "Tarp", "Ski Cords", "Ski Leash", "Radios"]),


### PR DESCRIPTION
## Summary
Adds "Alpine Draws" to the gear checklist for both climbing categories.

- **Rock Climbing** already included "Alpine Draws", so no change was needed there.
- **Ice Climbing** was missing it — added "Alpine Draws" to the `ice` category in `script.js`.

Now both the Rock Climbing and Ice Climbing generated checklists include alpine draws. Since the generator deduplicates items across selected categories, picking both still shows "Alpine Draws" only once.

https://claude.ai/code/session_01F9WcAvovAaooKd59AzBcrh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9WcAvovAaooKd59AzBcrh)_