### PR TITLE
Workout Logger v2 — template-driven tracker (replaces simple Strength Log)

### DIFF
--- a/STRENGTH_SETUP.md
+++ b/STRENGTH_SETUP.md
@@ -1,56 +1,73 @@
-# Strength Log — setup (≈5 minutes, one time)
+# Workout Logger — setup
 
-Your training log lives at **`strength.html`** on your existing GitHub Pages
-site. It uses a free [Supabase](https://supabase.com) project for login and
-data storage, so your history syncs across every device behind a real
-email/password login.
+The Workout Logger lives at **`strength.html`** on your GitHub Pages site and
+uses a free [Supabase](https://supabase.com) project (`strength-log`) for login
+and data, so your history syncs across every device behind an email/password
+login.
 
-## 1. Create a free Supabase project
-1. Go to <https://supabase.com> → **Start your project** → sign in with GitHub.
-2. **New project** → give it a name (e.g. `strength-log`), set a database
-   password (save it somewhere), pick a region near you, **Create**.
-3. Wait ~1 minute for it to provision.
+The Supabase project and keys are already wired in (see `strength-config.js`).
+If you ever rebuild the database, re-run the schema below.
 
-## 2. Create the database tables
-1. In the project, open **SQL Editor** → **New query**.
-2. Copy the entire contents of [`strength-schema.sql`](strength-schema.sql),
-   paste it in, and click **Run**. You should see "Success".
+## Database
 
-## 3. Plug in your keys
-1. In Supabase, open **Project Settings → API**.
-2. Copy two values:
-   - **Project URL** (looks like `https://abcd1234.supabase.co`)
-   - **anon / public** API key (a long string)
-3. Open [`strength-config.js`](strength-config.js) and paste them in:
-   ```js
-   window.STRENGTH_CONFIG = {
-     SUPABASE_URL: "https://abcd1234.supabase.co",
-     SUPABASE_ANON_KEY: "eyJ...your-anon-key..."
-   };
-   ```
-   The anon key is **safe to commit publicly** — Row Level Security (set up by
-   the schema) means it can only ever read/write rows owned by the logged-in
-   user.
-4. Commit and push the change. GitHub Pages redeploys automatically.
+In Supabase: **SQL Editor → New query**, paste all of
+[`strength-schema.sql`](strength-schema.sql), and **Run**. It:
 
-## 4. Create your login
-You want this limited to just you. Two options:
+- drops the old v1 tables (`sessions`, `exercise_sets`) if present — they were
+  empty placeholders,
+- creates the v2 model: `profiles`, `exercises`, `templates`,
+  `template_exercises`, `sessions`, `set_logs`,
+- enables **Row Level Security** so every row is visible only to its owner
+  (built-in seed exercises, `user_id = NULL`, are readable by everyone),
+- seeds the built-in exercise library.
 
-- **Easiest:** open `strength.html`, click **"Need an account? Sign up"**,
-  enter your email + a password. (By default Supabase emails a confirmation
-  link — click it, then sign in.)
-- **Or** create the user directly in Supabase: **Authentication → Users →
-  Add user**.
+Running it shows a "destructive operations" warning because it `drop`s the old
+tables and replaces policies — expected and safe on the empty project.
 
-**To keep it private to you:** in Supabase go to **Authentication → Providers
-→ Email** and turn **off** "Allow new users to sign up" after your account
-exists. From then on, only you can log in.
+## Data model (adapted to Supabase)
 
-## Done
-Visit `…/strength.html`, sign in, and start logging. Features:
-- **Log Session** — date/time (defaults to now), a 1–5 star session rating,
-  any number of exercises with weight / reps / set number, and notes.
-- **History** — every past session, newest first, with date, timestamp,
-  rating, and all lifts.
-- **By Exercise** — pick a lift to see its full weight history, your best
-  weight (PR), and when you last did it.
+The build-guide schema assumed a generic `users` table with `BIGINT` ids. Here
+it's mapped to the Supabase reality:
+
+- `user_id` is **`uuid`** referencing `auth.users(id)`, default `auth.uid()`.
+- Access is enforced by **RLS policies**, not an app server.
+- `weight_unit` (lb/kg) is a per-user setting on the **`profiles`** table.
+- Every user-owned table carries `user_id` so RLS stays simple and fast.
+
+Everything else from the guide is preserved: text ranges for targets, `weight`
+as `NUMERIC(6,2)`, `finished_at IS NULL` = in-progress (powers resume), the
+unique constraints that make autosave idempotent, and the indexes.
+
+## Login
+
+1. Open `strength.html`, click **"Need an account? Sign up"**, enter email +
+   password. Supabase emails a confirmation link by default — click it, then
+   sign in.
+2. **To keep it private to you:** in Supabase → **Authentication → Providers →
+   Email**, turn **off** "Allow new users to sign up" after your account exists.
+
+## Features
+
+- **Workouts** — your templates as cards (name, phase, exercise count). Start a
+  template or a freeform session. Create/edit templates (sections, targets,
+  reorder). On first login, two starter templates are created from the seed
+  library.
+- **Active session** — exercises grouped by section, each with set rows
+  (weight + reps steppers, tap-to-type, large done checkbox). Shows the
+  "last time" value inline, marks a PR with ▲, autosaves every change, and
+  resumes exactly where you left off if the tab closes. Optional rest timer
+  from the target rest.
+- **History** — finished sessions by month with a one-line summary; tap for a
+  read-only detail.
+- **Progress** — per exercise: best/last/sessions stats, a top-set-weight line
+  chart, a volume chart, and the raw history.
+- **Exercises** — searchable library grouped by muscle group, with an
+  "Add exercise" form for custom movements.
+- **Settings** (⚙️) — switch weight unit (lb/kg) and sign out.
+
+## Note on starter data
+
+The seed library is the guide's 7 exercises plus common core moves. The two
+starter templates ("Full Body Split", "Upper / Core Split") use those. Lower-
+body exercises aren't seeded yet — add them in the **Exercises** tab and build
+your own splits with the template editor.

--- a/strength-schema.sql
+++ b/strength-schema.sql
@@ -1,49 +1,174 @@
 -- ===========================================================================
--- Strength Log — database schema
--- Run this once in your Supabase project: Dashboard → SQL Editor → New query,
--- paste this whole file, then click "Run".
+-- Workout Logger — database schema (Supabase / Postgres)
+-- Run once: Dashboard → SQL Editor → New query → paste all → Run.
+--
+-- Adapted from the build-guide spec to this stack:
+--   * user_id is uuid referencing auth.users(id), default auth.uid()
+--   * security is enforced by Row Level Security (not an app server)
+--   * every user-data table carries user_id so RLS stays simple and fast
+--   * weight unit is a per-user setting on the profiles table
 -- ===========================================================================
 
--- A single training session (a visit to the gym).
+-- --- Replace v1 ------------------------------------------------------------
+-- The original simple Strength Log used these two tables. They are empty and
+-- unused; drop them so the names are free for the richer model below.
+drop table if exists public.exercise_sets cascade;
+-- (v1 also had public.sessions; it is recreated below with the new shape.)
+drop table if exists public.sessions cascade;
+
+-- --- Per-user settings -----------------------------------------------------
+create table if not exists public.profiles (
+  id          uuid primary key references auth.users (id) on delete cascade,
+  weight_unit text not null default 'lb' check (weight_unit in ('lb','kg')),
+  created_at  timestamptz not null default now()
+);
+
+-- --- Exercise library (shared seeds + user-created) ------------------------
+-- user_id NULL  = built-in seed exercise (readable by everyone)
+-- user_id set   = custom exercise owned by that user
+create table if not exists public.exercises (
+  id           bigint generated always as identity primary key,
+  user_id      uuid references auth.users (id) on delete cascade,
+  name         text not null,
+  muscle_group text,
+  equipment    text,
+  description  text,
+  created_at   timestamptz not null default now()
+);
+
+create table if not exists public.templates (
+  id         bigint generated always as identity primary key,
+  user_id    uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  name       text not null,
+  phase      text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.template_exercises (
+  id          bigint generated always as identity primary key,
+  template_id bigint not null references public.templates (id) on delete cascade,
+  exercise_id bigint not null references public.exercises (id) on delete restrict,
+  user_id     uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  section     text,
+  position    integer not null,
+  target_sets text,
+  target_reps text,
+  target_rest text,
+  unique (template_id, position)
+);
+
 create table if not exists public.sessions (
-  id           uuid primary key default gen_random_uuid(),
+  id           bigint generated always as identity primary key,
   user_id      uuid not null default auth.uid() references auth.users (id) on delete cascade,
-  performed_at timestamptz not null default now(),
-  rating       int check (rating between 1 and 5),
-  notes        text,
-  created_at   timestamptz not null default now()
+  template_id  bigint references public.templates (id) on delete set null,
+  performed_on date not null default current_date,
+  started_at   timestamptz not null default now(),
+  finished_at  timestamptz,
+  notes        text
 );
 
--- A single set of a single exercise, belonging to a session.
-create table if not exists public.exercise_sets (
-  id           uuid primary key default gen_random_uuid(),
-  session_id   uuid not null references public.sessions (id) on delete cascade,
-  user_id      uuid not null default auth.uid() references auth.users (id) on delete cascade,
-  exercise     text not null,
-  weight       numeric,
-  reps         int,
-  set_number   int,
-  created_at   timestamptz not null default now()
+create table if not exists public.set_logs (
+  id          bigint generated always as identity primary key,
+  session_id  bigint not null references public.sessions (id) on delete cascade,
+  exercise_id bigint not null references public.exercises (id) on delete restrict,
+  user_id     uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  set_number  integer not null,
+  weight      numeric(6,2),
+  reps        integer,
+  completed   boolean not null default false,
+  unique (session_id, exercise_id, set_number)
 );
 
-create index if not exists exercise_sets_session_idx  on public.exercise_sets (session_id);
-create index if not exists exercise_sets_exercise_idx on public.exercise_sets (user_id, exercise);
-create index if not exists sessions_user_time_idx      on public.sessions (user_id, performed_at desc);
+-- --- Indexes the app's queries actually use --------------------------------
+create index if not exists idx_sessions_user_date on public.sessions (user_id, performed_on desc);
+create index if not exists idx_setlogs_session    on public.set_logs (session_id);
+create index if not exists idx_setlogs_exercise   on public.set_logs (user_id, exercise_id);
+create index if not exists idx_tmplex_template    on public.template_exercises (template_id, position);
 
--- ---------------------------------------------------------------------------
--- Row Level Security: every user can only ever see/modify their own rows.
--- ---------------------------------------------------------------------------
-alter table public.sessions      enable row level security;
-alter table public.exercise_sets enable row level security;
+-- ===========================================================================
+-- Row Level Security
+-- ===========================================================================
+alter table public.profiles           enable row level security;
+alter table public.exercises          enable row level security;
+alter table public.templates          enable row level security;
+alter table public.template_exercises enable row level security;
+alter table public.sessions           enable row level security;
+alter table public.set_logs           enable row level security;
+
+-- profiles: a user sees/edits only their own row
+drop policy if exists "own profile" on public.profiles;
+create policy "own profile" on public.profiles
+  for all using (auth.uid() = id) with check (auth.uid() = id);
+
+-- exercises: everyone can read seeds + their own; can only write their own
+drop policy if exists "read exercises" on public.exercises;
+create policy "read exercises" on public.exercises
+  for select using (user_id is null or auth.uid() = user_id);
+
+drop policy if exists "insert own exercises" on public.exercises;
+create policy "insert own exercises" on public.exercises
+  for insert with check (auth.uid() = user_id);
+
+drop policy if exists "update own exercises" on public.exercises;
+create policy "update own exercises" on public.exercises
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+drop policy if exists "delete own exercises" on public.exercises;
+create policy "delete own exercises" on public.exercises
+  for delete using (auth.uid() = user_id);
+
+-- the remaining tables are strictly owner-scoped
+drop policy if exists "own templates" on public.templates;
+create policy "own templates" on public.templates
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+drop policy if exists "own template_exercises" on public.template_exercises;
+create policy "own template_exercises" on public.template_exercises
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
 
 drop policy if exists "own sessions" on public.sessions;
 create policy "own sessions" on public.sessions
-  for all
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
 
-drop policy if exists "own sets" on public.exercise_sets;
-create policy "own sets" on public.exercise_sets
-  for all
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+drop policy if exists "own set_logs" on public.set_logs;
+create policy "own set_logs" on public.set_logs
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+-- ===========================================================================
+-- Seed exercises (built-in, user_id = NULL).
+-- The 7 from the guide plus standard core moves the starter templates use.
+-- ===========================================================================
+insert into public.exercises (user_id, name, muscle_group, equipment, description)
+select * from (values
+  (null::uuid, 'Dumbbell Bench Press', 'Chest', 'Dumbbell',
+   'Lie flat on a bench, a dumbbell in each hand at chest level, palms forward. Press straight up until arms are nearly extended, then lower slowly to chest level. Chest with shoulders and triceps assisting.'),
+  (null, 'Bent Over Tricep Kickbacks', 'Triceps', 'Dumbbell',
+   'Hinge forward at the hips with a flat back, elbows bent ~90 degrees and tucked to your sides. Extend the forearms straight back until arms are straight, squeeze the triceps, then return. Upper arms stay still.'),
+  (null, 'Dumbbell Overhead Press', 'Shoulders', 'Dumbbell',
+   'Seated or standing, dumbbells at shoulder height, palms forward. Press overhead until arms are nearly straight, then lower under control. Brace the core, avoid arching the lower back.'),
+  (null, 'Front to Lateral Raise', 'Shoulders', 'Dumbbell',
+   'Raise both arms straight in front to shoulder height, lower, then raise out to the sides to shoulder height. Slight elbow bend, no swinging. Front and side delts.'),
+  (null, 'Cable Chest Flys', 'Chest', 'Cable',
+   'Stand between two cable stations, a handle in each hand, slight elbow bend. Bring the handles together in front of the chest in a wide arc, squeeze, then return slowly. Constant cable tension.'),
+  (null, 'Cable Tricep Extension', 'Triceps', 'Cable',
+   'Face the machine, attachment set high, elbows bent and tucked. Push down by straightening the arms fully, squeeze the triceps, then return under control. Upper arms pinned.'),
+  (null, 'Hanging Leg Raises', 'Core', 'Bodyweight',
+   'Hang from a pull-up bar, arms extended. Keeping legs straight (or bent for easier), raise them to about hip height or higher, then lower slowly without swinging. Lower abs and hip flexors.'),
+  (null, 'Plank', 'Core', 'Bodyweight',
+   'Forearms and toes on the floor, body in a straight line from head to heels. Brace the core and hold without letting the hips sag or pike.'),
+  (null, 'Russian Twist', 'Core', 'Bodyweight',
+   'Sit with knees bent and heels light on the floor, lean back slightly. Rotate the torso side to side, tapping the floor by each hip. Add a weight for difficulty.'),
+  (null, 'Leg Raise', 'Core', 'Bodyweight',
+   'Lie on your back, legs straight. Raise them to vertical keeping the lower back pressed down, then lower slowly without letting the heels touch.'),
+  (null, 'Bird Dog', 'Core', 'Bodyweight',
+   'On hands and knees, extend the opposite arm and leg until level with the torso, hold briefly, then switch. Keep the hips square and core braced.'),
+  (null, 'Hollow Body Hold', 'Core', 'Bodyweight',
+   'Lie on your back, press the lower back into the floor, then lift the shoulders and legs into a shallow banana shape. Hold while breathing.'),
+  (null, 'Side Plank', 'Core', 'Bodyweight',
+   'On one forearm and the side of the foot, lift the hips so the body is a straight line. Hold, then switch sides.'),
+  (null, 'Sit Ups', 'Core', 'Bodyweight',
+   'Lie on your back, knees bent. Curl all the way up to a seated position then lower under control.')
+) as v(user_id, name, muscle_group, equipment, description)
+where not exists (
+  select 1 from public.exercises e where e.user_id is null and e.name = v.name
+);

--- a/strength.html
+++ b/strength.html
@@ -1,279 +1,281 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Strength Log</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="theme-color" content="#2f855a" />
+<title>Workout Logger</title>
 <style>
-  *, *::before, *::after { box-sizing: border-box; }
-
+  :root {
+    --accent:      #2f855a;
+    --accent-ink:  #ffffff;
+    --accent-weak: #e6f2ec;
+    --accent-line: #b7dcc8;
+    --bg:          #f6f7f6;
+    --card:        #ffffff;
+    --ink:         #15201b;
+    --muted:       #6b7280;
+    --faint:       #9aa3ab;
+    --line:        #e5e7eb;
+    --danger:      #b4453a;
+    --radius:      16px;
+    --radius-sm:   11px;
+    --tap:         48px;
+    --maxw:        560px;
+    --safe-b:      env(safe-area-inset-bottom, 0px);
+  }
+  * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+  html, body { margin: 0; padding: 0; }
   body {
-    margin: 0; padding: 0;
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    background: url('mountain.jpg') no-repeat center center fixed;
-    background-size: cover;
-    min-height: 100vh;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--ink);
+    background: var(--bg);
+    font-size: 17px;
+    line-height: 1.4;
+    -webkit-font-smoothing: antialiased;
   }
-  body::before {
-    content: ''; position: fixed; inset: 0;
-    background: linear-gradient(135deg, rgba(15, 23, 42, 0.65), rgba(30, 58, 95, 0.55));
-    z-index: 0;
-  }
-  .container {
-    position: relative; z-index: 1;
-    display: flex; justify-content: center; align-items: flex-start;
-    min-height: 100vh; padding: 40px 20px;
-  }
-  .card {
-    background: rgba(255, 255, 255, 0.94);
-    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 20px;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.07), 0 20px 60px rgba(0,0,0,0.15);
-    padding: 36px 32px; max-width: 560px; width: 100%;
-    animation: slideUp 0.5s ease-out;
-  }
-  @keyframes slideUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
-  @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+  .wrap { max-width: var(--maxw); margin: 0 auto; min-height: 100vh; position: relative; }
 
-  .card-header { text-align: center; margin-bottom: 24px; }
-  .card-header .icon { font-size: 40px; margin-bottom: 8px; display: block; }
-  .card-header h1 {
-    font-family: 'Playfair Display', Georgia, serif;
-    font-size: 28px; font-weight: 700; color: #1e293b;
-    margin: 0 0 6px 0; letter-spacing: -0.5px;
-  }
-  .card-header p { color: #64748b; font-size: 14px; margin: 0; }
+  [hidden] { display: none !important; }
 
-  label.field-label {
-    display: block; font-size: 13px; font-weight: 600; color: #475569;
-    margin: 0 0 6px 2px; text-transform: uppercase; letter-spacing: 0.5px;
-  }
-  input[type=text], input[type=email], input[type=password],
-  input[type=number], input[type=datetime-local], textarea, select.select-styled {
-    width: 100%; appearance: none; -webkit-appearance: none;
-    background: #f8fafc; border: 1.5px solid #e2e8f0; border-radius: 10px;
-    padding: 11px 12px; font-size: 15px; font-family: 'Inter', sans-serif;
-    color: #1e293b; font-weight: 500; transition: all 0.2s ease;
-  }
-  textarea { resize: vertical; min-height: 60px; }
-  input:focus, textarea:focus, select:focus {
-    outline: none; border-color: #2d8a4e; box-shadow: 0 0 0 3px rgba(45,138,78,0.15);
-  }
-  select.select-styled {
-    cursor: pointer; padding-right: 34px;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2364748b' d='M6 8.825a.5.5 0 0 1-.354-.146l-4-4a.5.5 0 0 1 .708-.708L6 7.617l3.646-3.646a.5.5 0 0 1 .708.708l-4 4A.5.5 0 0 1 6 8.825z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat; background-position: right 12px center;
-  }
+  h1, h2, h3 { margin: 0; font-weight: 700; letter-spacing: -0.01em; }
+  .num { font-variant-numeric: tabular-nums; }
+  .muted { color: var(--muted); }
+  .faint { color: var(--faint); }
 
+  button { font: inherit; cursor: pointer; border: none; background: none; color: inherit; }
   .btn {
-    display: block; width: 100%; padding: 13px 24px;
-    background: linear-gradient(135deg, #2d8a4e, #22763f); color: white;
-    border: none; border-radius: 12px; font-size: 15px; font-weight: 600;
-    font-family: 'Inter', sans-serif; cursor: pointer; transition: all 0.25s ease;
-    letter-spacing: 0.3px; box-shadow: 0 2px 8px rgba(45,138,78,0.3);
+    display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+    min-height: var(--tap); padding: 0 20px; border-radius: 999px;
+    background: var(--accent); color: var(--accent-ink); font-weight: 650; font-size: 17px;
+    width: 100%;
   }
-  .btn:hover { background: linear-gradient(135deg, #22763f, #1a5c31); transform: translateY(-1px); }
-  .btn:disabled { opacity: 0.55; cursor: not-allowed; transform: none; }
-  .btn-secondary {
-    background: #f1f5f9; color: #475569; border: 1.5px solid #e2e8f0; box-shadow: none;
+  .btn:active { transform: translateY(1px); }
+  .btn.secondary { background: var(--card); color: var(--ink); border: 1.5px solid var(--line); }
+  .btn.ghost { background: transparent; color: var(--accent); min-height: 44px; font-weight: 600; width: auto; padding: 0 8px; }
+  .btn.danger { background: transparent; color: var(--danger); border: 1.5px solid #e6c6c2; }
+  .btn.small { min-height: 38px; font-size: 15px; padding: 0 14px; width: auto; }
+
+  input, select, textarea {
+    font: inherit; color: var(--ink); background: var(--card);
+    border: 1.5px solid var(--line); border-radius: var(--radius-sm);
+    padding: 12px 14px; width: 100%; min-height: var(--tap);
   }
-  .btn-secondary:hover { background: #e2e8f0; transform: none; }
-  .btn-ghost {
-    width: auto; display: inline-block; padding: 8px 14px; font-size: 13px;
-    background: #f1f5f9; color: #475569; border: 1.5px solid #e2e8f0; box-shadow: none;
-    border-radius: 9px;
+  input:focus, select:focus, textarea:focus { outline: none; border-color: var(--accent); }
+  label.field { display: block; margin-bottom: 14px; }
+  label.field > span { display: block; font-size: 13px; font-weight: 650; color: var(--muted);
+    text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 6px; }
+
+  .screen { padding: 18px 16px calc(96px + var(--safe-b)); }
+  .topbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 18px; }
+  .topbar h1 { font-size: 26px; }
+
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 16px; margin-bottom: 14px; }
+  .card.tap { display: block; width: 100%; text-align: left; }
+  .card.tap:active { background: #fbfcfb; }
+
+  .pill { display: inline-block; font-size: 12px; font-weight: 650; padding: 3px 9px; border-radius: 999px;
+    background: var(--accent-weak); color: var(--accent); border: 1px solid var(--accent-line); }
+  .row { display: flex; align-items: center; gap: 12px; }
+  .grow { flex: 1; min-width: 0; }
+  .stack > * + * { margin-top: 10px; }
+  .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  .empty { text-align: center; color: var(--muted); padding: 40px 16px; }
+  .empty .big { font-size: 40px; margin-bottom: 10px; }
+
+  .section-head { font-size: 13px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--faint); margin: 22px 4px 8px; }
+
+  #view-auth, #view-setup {
+    min-height: 100vh; display: flex; align-items: center; justify-content: center;
+    padding: 24px; background: linear-gradient(160deg, #2f855a 0%, #1f5d40 100%);
   }
-  .btn-ghost:hover { background: #e2e8f0; transform: none; }
+  .auth-card { background: var(--card); border-radius: 22px; padding: 30px 24px; width: 100%; max-width: 380px;
+    box-shadow: 0 18px 50px rgba(0,0,0,.25); }
+  .auth-card .logo { font-size: 42px; text-align: center; }
+  .auth-card h1 { text-align: center; font-size: 27px; margin: 6px 0 2px; }
+  .auth-card .tag { text-align: center; color: var(--muted); margin-bottom: 22px; }
+  .auth-toggle { text-align: center; margin-top: 16px; }
+  .msg { margin-top: 14px; padding: 11px 13px; border-radius: 10px; font-size: 15px; display: none; }
+  .msg.show { display: block; }
+  .msg.err { background: #fbecea; color: var(--danger); }
+  .msg.ok  { background: var(--accent-weak); color: var(--accent); }
 
-  .row { margin-bottom: 16px; }
-  .grid-3 { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 8px; }
-  .grid-3 .field-label { display: none; }
+  .tabbar { position: fixed; left: 0; right: 0; bottom: 0; z-index: 30;
+    background: rgba(255,255,255,.94); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line); display: flex; padding-bottom: var(--safe-b); }
+  .tabbar .wrapinner { max-width: var(--maxw); margin: 0 auto; display: flex; width: 100%; }
+  .tabbtn { flex: 1; min-height: 60px; display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 3px; color: var(--faint); font-size: 11px; font-weight: 600; }
+  .tabbtn .ic { font-size: 21px; line-height: 1; }
+  .tabbtn[aria-selected="true"] { color: var(--accent); }
 
-  /* Tabs */
-  .tabs { display: flex; gap: 6px; margin-bottom: 22px; background: #f1f5f9; padding: 5px; border-radius: 12px; }
-  .tab {
-    flex: 1; text-align: center; padding: 9px 8px; border-radius: 8px; cursor: pointer;
-    font-size: 13.5px; font-weight: 600; color: #64748b; transition: all 0.2s ease; user-select: none;
-  }
-  .tab.active { background: white; color: #1e293b; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  #view-session, #view-progress, #view-detail {
+    position: fixed; inset: 0; background: var(--bg); z-index: 40; overflow-y: auto;
+    max-width: var(--maxw); margin: 0 auto; }
+  .sessionhead { position: sticky; top: 0; z-index: 5; background: rgba(246,247,246,.95); backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--line); padding: 14px 16px; display: flex; align-items: center; gap: 12px; }
+  .sessionhead .ttl { font-size: 17px; font-weight: 700; }
+  .sessionhead .sub { font-size: 13px; color: var(--muted); }
 
-  /* Stars */
-  .stars { display: flex; gap: 6px; }
-  .star {
-    font-size: 30px; line-height: 1; cursor: pointer; color: #cbd5e1; transition: color 0.15s ease;
-  }
-  .star.on { color: #f59e0b; }
+  .ex-card { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 14px; margin-bottom: 14px; }
+  .ex-card .exname { font-size: 18px; font-weight: 700; }
+  .ex-card .extarget { font-size: 13px; color: var(--muted); margin-top: 2px; }
 
-  .topbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 18px; }
-  .topbar .who { font-size: 12.5px; color: #94a3b8; }
+  .setrow { display: grid; grid-template-columns: 24px 1fr 1fr 50px; gap: 8px; align-items: end;
+    padding: 10px 0; border-top: 1px solid var(--line); }
+  .setrow .setn { font-size: 15px; font-weight: 700; color: var(--faint); text-align: center; padding-bottom: 12px; }
+  .lasthint { grid-column: 2 / 4; font-size: 12px; color: var(--faint); margin: 2px 0 -2px; min-height: 14px; }
 
-  .set-row { position: relative; }
-  .set-row .remove {
-    position: absolute; top: -8px; right: -8px; width: 22px; height: 22px;
-    border-radius: 50%; border: none; background: #ef4444; color: white; cursor: pointer;
-    font-size: 14px; line-height: 1; display: none;
-  }
-  .set-block { border: 1.5px solid #f1f5f9; border-radius: 12px; padding: 12px; margin-bottom: 10px; position: relative; }
-  .set-block .remove {
-    position: absolute; top: 8px; right: 8px; width: 24px; height: 24px;
-    border-radius: 50%; border: none; background: #fee2e2; color: #b91c1c; cursor: pointer;
-    font-size: 15px; line-height: 1; font-weight: 700;
-  }
+  .cell .steplabel { font-size: 10px; font-weight: 650; color: var(--faint); text-transform: uppercase; letter-spacing: .04em;
+    margin-bottom: 3px; display: block; }
+  .stepper { display: flex; align-items: stretch; border: 1.5px solid var(--line); border-radius: 12px; overflow: hidden;
+    background: var(--card); }
+  .stepper button { width: 38px; flex: none; font-size: 22px; font-weight: 600; color: var(--accent);
+    display: flex; align-items: center; justify-content: center; }
+  .stepper button:active { background: var(--accent-weak); }
+  .stepper input { border: none; border-radius: 0; text-align: center; padding: 10px 2px; min-height: 46px;
+    font-size: 19px; font-weight: 700; font-variant-numeric: tabular-nums; width: 100%; }
 
-  .session-card {
-    border: 1.5px solid #f1f5f9; border-radius: 14px; padding: 16px; margin-bottom: 14px;
-    animation: fadeIn 0.3s ease;
-  }
-  .session-card .sc-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
-  .session-card .sc-date { font-size: 14px; font-weight: 700; color: #1e293b; }
-  .session-card .sc-time { font-size: 12px; color: #94a3b8; font-weight: 500; }
-  .session-card .sc-rating { color: #f59e0b; font-size: 14px; letter-spacing: 1px; }
-  .session-card .sc-notes { font-size: 13px; color: #64748b; font-style: italic; margin: 6px 0 8px; }
-  .ex-line { display: flex; justify-content: space-between; font-size: 14px; padding: 4px 0; border-top: 1px solid #f8fafc; }
-  .ex-line .ex-name { color: #334155; font-weight: 500; }
-  .ex-line .ex-detail { color: #64748b; }
+  .donebox { width: 46px; height: 46px; border-radius: 13px; border: 2px solid var(--line); background: var(--card);
+    display: flex; align-items: center; justify-content: center; font-size: 22px; color: transparent; justify-self: end; }
+  .donebox.on { background: var(--accent); border-color: var(--accent); color: #fff; }
 
-  .hist-table { width: 100%; border-collapse: collapse; font-size: 14px; }
-  .hist-table th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: #94a3b8; padding: 8px 6px; border-bottom: 2px solid #f1f5f9; }
-  .hist-table td { padding: 9px 6px; border-bottom: 1px solid #f8fafc; color: #334155; }
-  .hist-table td.num { font-variant-numeric: tabular-nums; }
-  .pr-badge { display: inline-block; background: #dcfce7; color: #15803d; font-size: 10px; font-weight: 700; padding: 1px 6px; border-radius: 999px; margin-left: 6px; vertical-align: middle; }
+  .ex-card.allset { border-color: var(--accent-line); background: #fbfdfc; }
+  .beat { color: var(--accent); font-weight: 700; }
 
-  .empty { text-align: center; color: #94a3b8; font-size: 14px; padding: 30px 10px; }
-  .muted { color: #94a3b8; font-size: 12.5px; }
-  .toast {
-    position: fixed; bottom: 22px; left: 50%; transform: translateX(-50%);
-    background: #1e293b; color: white; padding: 11px 20px; border-radius: 10px;
-    font-size: 14px; z-index: 50; opacity: 0; transition: opacity 0.25s ease; pointer-events: none;
-  }
-  .toast.show { opacity: 1; }
-  .err { color: #b91c1c; font-size: 13px; margin-top: 10px; text-align: center; min-height: 18px; }
-  .stat-strip { display: flex; gap: 10px; margin: 4px 0 16px; }
-  .stat { flex: 1; background: #f8fafc; border-radius: 12px; padding: 12px; text-align: center; }
-  .stat .v { font-size: 20px; font-weight: 700; color: #1e293b; }
-  .stat .k { font-size: 11px; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.5px; }
-  .add-link { background: none; border: none; color: #2d8a4e; font-weight: 600; font-size: 13.5px; cursor: pointer; padding: 4px 0; font-family: inherit; }
-  .hidden { display: none !important; }
+  .resttimer { position: fixed; left: 50%; transform: translateX(-50%); bottom: calc(18px + var(--safe-b)); z-index: 50;
+    background: var(--ink); color: #fff; border-radius: 999px; padding: 10px 18px; font-weight: 700;
+    font-variant-numeric: tabular-nums; box-shadow: 0 8px 24px rgba(0,0,0,.3); display: flex; align-items: center; gap: 14px; }
+  .resttimer button { color: #cfe9da; font-weight: 700; }
 
-  @media (max-width: 560px) {
-    .card { padding: 26px 18px; border-radius: 16px; }
-    .card-header h1 { font-size: 24px; }
+  .resume-banner { background: var(--accent); color: #fff; border-radius: var(--radius); padding: 14px 16px;
+    margin-bottom: 16px; display: flex; align-items: center; gap: 12px; }
+  .resume-banner .grow { font-weight: 600; }
+  .resume-banner button { background: #fff; color: var(--accent); border-radius: 999px; min-height: 40px; padding: 0 16px;
+    font-weight: 700; flex: none; }
+
+  .iconbtn { width: 44px; height: 44px; border-radius: 12px; display: flex; align-items: center; justify-content: center;
+    font-size: 24px; color: var(--ink); flex: none; }
+  .iconbtn:active { background: var(--line); }
+
+  .chartwrap { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 16px; margin-bottom: 14px; }
+  .chartwrap h3 { font-size: 14px; color: var(--muted); margin-bottom: 10px; font-weight: 650; }
+  svg.chart { width: 100%; height: 150px; display: block; overflow: visible; }
+  .stat-row { display: flex; gap: 12px; margin-bottom: 14px; }
+  .stat { flex: 1; background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 12px 14px; }
+  .stat .k { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
+  .stat .v { font-size: 22px; font-weight: 800; font-variant-numeric: tabular-nums; }
+
+  .modal-back { position: fixed; inset: 0; background: rgba(0,0,0,.4); z-index: 60; display: flex; align-items: flex-end;
+    justify-content: center; }
+  .sheet { background: var(--card); width: 100%; max-width: var(--maxw); border-radius: 22px 22px 0 0;
+    padding: 20px 18px calc(24px + var(--safe-b)); max-height: 90vh; overflow-y: auto; }
+  .sheet h2 { font-size: 20px; margin-bottom: 14px; }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; animation: none !important; }
+    .btn:active { transform: none; }
   }
 </style>
 </head>
 <body>
-<div class="container">
-  <div class="card">
 
-    <div class="card-header">
-      <span class="icon">&#127947;</span>
-      <h1>Strength Log</h1>
-      <p id="subtitle">Track every lift, every session</p>
-    </div>
-
-    <!-- SETUP NEEDED -->
-    <div id="view-setup" class="hidden">
-      <div class="empty" style="text-align:left">
-        <p style="font-weight:600;color:#1e293b;font-size:15px">Almost there — one setup step.</p>
-        <p>This app needs a free Supabase project to store your logs. Open
-          <code>strength-config.js</code> and paste in your Supabase
-          <b>URL</b> and <b>anon key</b> (Project Settings → API), then run
-          <code>strength-schema.sql</code> in the Supabase SQL editor.</p>
-        <p class="muted">See <code>STRENGTH_SETUP.md</code> for the full 3-step guide.</p>
-      </div>
-    </div>
-
-    <!-- LOGIN -->
-    <div id="view-auth" class="hidden">
-      <div class="row">
-        <label class="field-label" for="email">Email</label>
-        <input type="email" id="email" autocomplete="username" placeholder="you@example.com">
-      </div>
-      <div class="row">
-        <label class="field-label" for="password">Password</label>
-        <input type="password" id="password" autocomplete="current-password" placeholder="••••••••">
-      </div>
-      <button class="btn" id="btn-login">Sign In</button>
-      <div class="err" id="auth-err"></div>
-      <p style="text-align:center;margin:14px 0 0">
-        <button class="add-link" id="toggle-signup">Need an account? Sign up</button>
-      </p>
-    </div>
-
-    <!-- APP -->
-    <div id="view-app" class="hidden">
-      <div class="topbar">
-        <span class="who" id="who"></span>
-        <button class="btn-ghost" id="btn-logout">Sign out</button>
-      </div>
-
-      <div class="tabs">
-        <div class="tab active" data-tab="log">Log Session</div>
-        <div class="tab" data-tab="history">History</div>
-        <div class="tab" data-tab="exercise">By Exercise</div>
-      </div>
-
-      <!-- TAB: LOG -->
-      <div id="tab-log" class="tab-panel">
-        <div class="row">
-          <label class="field-label" for="performed_at">Date &amp; time</label>
-          <input type="datetime-local" id="performed_at">
-        </div>
-
-        <div class="row">
-          <label class="field-label">How did the session feel?</label>
-          <div class="stars" id="rating-stars">
-            <span class="star" data-v="1">&#9733;</span>
-            <span class="star" data-v="2">&#9733;</span>
-            <span class="star" data-v="3">&#9733;</span>
-            <span class="star" data-v="4">&#9733;</span>
-            <span class="star" data-v="5">&#9733;</span>
-          </div>
-        </div>
-
-        <div class="row">
-          <label class="field-label">Exercises</label>
-          <div id="sets-container"></div>
-          <button class="add-link" id="add-set">+ Add another set</button>
-        </div>
-
-        <div class="row">
-          <label class="field-label" for="notes">Notes (optional)</label>
-          <textarea id="notes" placeholder="Felt strong, tweaked form on squats…"></textarea>
-        </div>
-
-        <button class="btn" id="btn-save">Save Session</button>
-        <div class="err" id="save-err"></div>
-      </div>
-
-      <!-- TAB: HISTORY -->
-      <div id="tab-history" class="tab-panel hidden">
-        <div id="history-list"><div class="empty">Loading…</div></div>
-      </div>
-
-      <!-- TAB: BY EXERCISE -->
-      <div id="tab-exercise" class="tab-panel hidden">
-        <div class="row">
-          <label class="field-label" for="ex-picker">Pick an exercise</label>
-          <select id="ex-picker" class="select-styled"></select>
-        </div>
-        <div id="ex-stats"></div>
-        <div id="ex-history"></div>
-      </div>
-    </div>
-
+<section id="view-setup" hidden>
+  <div class="auth-card">
+    <div class="logo">🏋️</div>
+    <h1>Almost there</h1>
+    <p class="tag">This app needs its Supabase keys.</p>
+    <p class="muted" style="font-size:15px">Open <code>strength-config.js</code> and add your project URL and publishable key, then reload. See <code>STRENGTH_SETUP.md</code>.</p>
   </div>
+</section>
+
+<section id="view-auth" hidden>
+  <div class="auth-card">
+    <div class="logo">🏋️</div>
+    <h1>Workout Logger</h1>
+    <p class="tag" id="auth-tag">Sign in to your account</p>
+    <form id="auth-form" class="stack">
+      <label class="field"><span>Email</span>
+        <input id="auth-email" type="email" autocomplete="email" placeholder="you@example.com" required />
+      </label>
+      <label class="field"><span>Password</span>
+        <input id="auth-password" type="password" autocomplete="current-password" placeholder="••••••••" required minlength="6" />
+      </label>
+      <button class="btn" type="submit" id="auth-submit">Sign In</button>
+    </form>
+    <div id="auth-msg" class="msg"></div>
+    <div class="auth-toggle">
+      <button class="btn ghost" id="auth-switch">Need an account? Sign up</button>
+    </div>
+  </div>
+</section>
+
+<div id="view-app" class="wrap" hidden>
+  <section id="tab-templates" class="screen tab">
+    <div class="topbar"><h1>Workouts</h1>
+      <button class="iconbtn" id="open-settings" title="Settings">⚙️</button>
+    </div>
+    <div id="resume-slot"></div>
+    <div id="templates-list"></div>
+    <div style="margin-top:18px" class="stack">
+      <button class="btn secondary" id="freeform-btn">+ Freeform session</button>
+      <button class="btn ghost" id="new-template-btn" style="width:100%">+ New template</button>
+    </div>
+  </section>
+
+  <section id="tab-history" class="screen tab" hidden>
+    <div class="topbar"><h1>History</h1></div>
+    <div id="history-list"></div>
+  </section>
+
+  <section id="tab-exercises" class="screen tab" hidden>
+    <div class="topbar"><h1>Exercises</h1>
+      <button class="btn ghost" id="add-exercise-btn">+ Add</button>
+    </div>
+    <input id="ex-search" type="search" placeholder="Search exercises…" style="margin-bottom:16px" />
+    <div id="exercises-list"></div>
+  </section>
+
+  <nav class="tabbar"><div class="wrapinner">
+    <button class="tabbtn" data-tab="templates" aria-selected="true"><span class="ic">🏠</span>Workouts</button>
+    <button class="tabbtn" data-tab="history" aria-selected="false"><span class="ic">📅</span>History</button>
+    <button class="tabbtn" data-tab="exercises" aria-selected="false"><span class="ic">📖</span>Exercises</button>
+  </div></nav>
 </div>
 
-<datalist id="exercise-options"></datalist>
-<div class="toast" id="toast"></div>
+<section id="view-session" hidden>
+  <div class="sessionhead">
+    <button class="iconbtn" id="session-back" title="Minimize">‹</button>
+    <div class="grow"><div class="ttl" id="session-title">Session</div><div class="sub" id="session-sub"></div></div>
+    <button class="btn small" id="session-finish">Finish</button>
+  </div>
+  <div class="screen" style="padding-top:14px" id="session-body"></div>
+</section>
 
-<script src="strength-config.js"></script>
+<section id="view-progress" hidden>
+  <div class="sessionhead">
+    <button class="iconbtn" id="progress-back" title="Back">‹</button>
+    <div class="grow"><div class="ttl" id="progress-title">Progress</div><div class="sub" id="progress-sub"></div></div>
+  </div>
+  <div class="screen" style="padding-top:14px" id="progress-body"></div>
+</section>
+
+<section id="view-detail" hidden>
+  <div class="sessionhead">
+    <button class="iconbtn" id="detail-back" title="Back">‹</button>
+    <div class="grow"><div class="ttl" id="detail-title">Session</div><div class="sub" id="detail-sub"></div></div>
+  </div>
+  <div class="screen" style="padding-top:14px" id="detail-body"></div>
+</section>
+
+<div id="modal-root"></div>
+
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script src="strength-config.js"></script>
 <script src="strength.js"></script>
 </body>
 </html>

--- a/strength.js
+++ b/strength.js
@@ -1,401 +1,976 @@
 /* ===========================================================================
- * Strength Log — client logic (Supabase auth + Postgres with RLS)
+ * Workout Logger — client logic
+ * Vanilla JS + Supabase (auth + Postgres with Row Level Security).
+ * Mobile-first; optimized for fast one-handed logging at the gym.
  * =========================================================================== */
 (function () {
-  "use strict";
+  'use strict';
 
-  // A starter set of common strength exercises. You can also type your own —
-  // anything you log becomes a future option automatically.
-  var DEFAULT_EXERCISES = [
-    "Back Squat", "Front Squat", "Deadlift", "Romanian Deadlift",
-    "Bench Press", "Incline Bench Press", "Overhead Press",
-    "Barbell Row", "Pull-up", "Lat Pulldown", "Seated Cable Row",
-    "Dumbbell Curl", "Tricep Pushdown", "Leg Press", "Leg Curl",
-    "Leg Extension", "Hip Thrust", "Lunge", "Calf Raise",
-    "Lateral Raise", "Face Pull", "Plank", "Hanging Leg Raise"
-  ];
-
-  var $ = function (id) { return document.getElementById(id); };
+  /* ----------------------------------------------------------------------- *
+   * Config & Supabase client
+   * ----------------------------------------------------------------------- */
   var cfg = window.STRENGTH_CONFIG || {};
-  var sb = null;
-  var currentRating = 0;
-  var knownExercises = DEFAULT_EXERCISES.slice();
-
-  // ---- view switching ------------------------------------------------------
-  function show(viewId) {
-    ["view-setup", "view-auth", "view-app"].forEach(function (v) {
-      $(v).classList.toggle("hidden", v !== viewId);
-    });
-  }
-
-  function toast(msg) {
-    var t = $("toast");
-    t.textContent = msg;
-    t.classList.add("show");
-    setTimeout(function () { t.classList.remove("show"); }, 2200);
-  }
-
-  function isConfigured() {
+  function configured() {
     return cfg.SUPABASE_URL && cfg.SUPABASE_ANON_KEY &&
-      cfg.SUPABASE_URL.indexOf("YOUR_SUPABASE") === -1 &&
-      cfg.SUPABASE_ANON_KEY.indexOf("YOUR_SUPABASE") === -1;
+      String(cfg.SUPABASE_URL).indexOf('YOUR_SUPABASE') === -1 &&
+      String(cfg.SUPABASE_ANON_KEY).indexOf('YOUR_SUPABASE') === -1;
+  }
+  var sb = null;
+
+  /* ----------------------------------------------------------------------- *
+   * Small helpers
+   * ----------------------------------------------------------------------- */
+  function $(id) { return document.getElementById(id); }
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+  function show(viewId) {
+    ['view-setup', 'view-auth', 'view-app'].forEach(function (v) {
+      var n = $(v); if (n) n.hidden = (v !== viewId);
+    });
+  }
+  function overlay(id, on) { var n = $(id); if (n) n.hidden = !on; }
+  function fmtW(w) {
+    if (w == null || w === '') return '–';
+    var n = Number(w);
+    return (n % 1 === 0) ? String(n) : String(n);
+  }
+  var MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  function parseDate(d) { var p = String(d).split('-'); return new Date(+p[0], +p[1] - 1, +p[2]); }
+  function fmtDate(d) { var x = parseDate(d); return MONTHS[x.getMonth()] + ' ' + x.getDate(); }
+  function fmtDateFull(d) { var x = parseDate(d); return MONTHS[x.getMonth()] + ' ' + x.getDate() + ', ' + x.getFullYear(); }
+  function monthLabel(d) { var x = parseDate(d); return MONTHS[x.getMonth()] + ' ' + x.getFullYear(); }
+  function maxInt(text, dflt) {
+    var nums = String(text || '').match(/\d+/g);
+    if (!nums) return dflt;
+    return nums.reduce(function (a, b) { return Math.max(a, +b); }, 0) || dflt;
+  }
+  function restSeconds(text) {
+    var n = String(text || '').match(/\d+/);
+    return n ? (+n[0]) * 60 : 0;
+  }
+  function debounce(fn, ms) {
+    var t; return function () { var a = arguments, self = this;
+      clearTimeout(t); t = setTimeout(function () { fn.apply(self, a); }, ms); };
   }
 
-  // ---- date helpers --------------------------------------------------------
-  function localDatetimeValue(d) {
-    // Format a Date as a value for <input type=datetime-local> in local time.
-    var pad = function (n) { return String(n).padStart(2, "0"); };
-    return d.getFullYear() + "-" + pad(d.getMonth() + 1) + "-" + pad(d.getDate()) +
-      "T" + pad(d.getHours()) + ":" + pad(d.getMinutes());
+  /* ----------------------------------------------------------------------- *
+   * App state
+   * ----------------------------------------------------------------------- */
+  var state = {
+    user: null,
+    profile: { weight_unit: 'lb' },
+    exercises: [],          // full library (seeds + user)
+    exById: {},
+    tab: 'templates',
+    active: null            // active session model (see startSession)
+  };
+  function unit() { return state.profile.weight_unit || 'lb'; }
+  function wStep() { return unit() === 'kg' ? 1.25 : 2.5; }
+
+  var STARTERS = [
+    { name: 'Full Body Split', phase: 'Month 1', items: [
+      { name: 'Dumbbell Bench Press', section: 'UPPER BODY' },
+      { name: 'Dumbbell Overhead Press', section: 'UPPER BODY' },
+      { name: 'Cable Chest Flys', section: 'UPPER BODY' },
+      { name: 'Bent Over Tricep Kickbacks', section: 'UPPER BODY' },
+      { name: 'Cable Tricep Extension', section: 'UPPER BODY' },
+      { name: 'Hanging Leg Raises', section: 'CORE' },
+      { name: 'Plank', section: 'CORE' }
+    ] },
+    { name: 'Upper / Core Split', phase: 'Month 1', items: [
+      { name: 'Dumbbell Bench Press', section: 'UPPER BODY' },
+      { name: 'Cable Chest Flys', section: 'UPPER BODY' },
+      { name: 'Dumbbell Overhead Press', section: 'UPPER BODY' },
+      { name: 'Front to Lateral Raise', section: 'UPPER BODY' },
+      { name: 'Cable Tricep Extension', section: 'UPPER BODY' },
+      { name: 'Hanging Leg Raises', section: 'CORE' },
+      { name: 'Hollow Body Hold', section: 'CORE' },
+      { name: 'Russian Twist', section: 'CORE' },
+      { name: 'Side Plank', section: 'CORE' }
+    ] }
+  ];
+  var M1 = { target_sets: '3', target_reps: '10-15', target_rest: '2-3 min' };
+
+  /* ----------------------------------------------------------------------- *
+   * Auth
+   * ----------------------------------------------------------------------- */
+  var authMode = 'signin';
+  function authMsg(text, kind) {
+    var m = $('auth-msg');
+    m.textContent = text || '';
+    m.className = 'msg' + (text ? ' show ' + (kind || '') : '');
   }
-  function fmtDate(iso) {
-    return new Date(iso).toLocaleDateString(undefined,
-      { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+  function setAuthMode(mode) {
+    authMode = mode;
+    $('auth-tag').textContent = mode === 'signin' ? 'Sign in to your account' : 'Create your account';
+    $('auth-submit').textContent = mode === 'signin' ? 'Sign In' : 'Sign Up';
+    $('auth-switch').textContent = mode === 'signin' ? 'Need an account? Sign up' : 'Have an account? Sign in';
+    $('auth-password').setAttribute('autocomplete', mode === 'signin' ? 'current-password' : 'new-password');
+    authMsg('');
   }
-  function fmtTime(iso) {
-    return new Date(iso).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  function wireAuth() {
+    $('auth-switch').addEventListener('click', function () {
+      setAuthMode(authMode === 'signin' ? 'signup' : 'signin');
+    });
+    $('auth-form').addEventListener('submit', function (e) {
+      e.preventDefault();
+      var email = $('auth-email').value.trim();
+      var pw = $('auth-password').value;
+      var btn = $('auth-submit'); btn.disabled = true;
+      var done = function () { btn.disabled = false; };
+      if (authMode === 'signup') {
+        sb.auth.signUp({ email: email, password: pw }).then(function (r) {
+          done();
+          if (r.error) return authMsg(r.error.message, 'err');
+          if (r.data && r.data.session) return; // auto-confirmed → onAuthStateChange boots
+          authMsg('Account created. Check your email to confirm, then sign in.', 'ok');
+          setAuthMode('signin');
+        });
+      } else {
+        sb.auth.signInWithPassword({ email: email, password: pw }).then(function (r) {
+          done();
+          if (r.error) return authMsg(r.error.message, 'err');
+        });
+      }
+    });
+  }
+  function signOut() { sb.auth.signOut(); }
+
+  /* ----------------------------------------------------------------------- *
+   * Data layer
+   * ----------------------------------------------------------------------- */
+  function ensureProfile() {
+    return sb.from('profiles').select('weight_unit').eq('id', state.user.id).maybeSingle()
+      .then(function (r) {
+        if (r.data) { state.profile.weight_unit = r.data.weight_unit; return; }
+        return sb.from('profiles').insert({ id: state.user.id, weight_unit: 'lb' }).then(function () {});
+      });
+  }
+  function setUnit(u) {
+    state.profile.weight_unit = u;
+    return sb.from('profiles').update({ weight_unit: u }).eq('id', state.user.id);
+  }
+  function loadExercises() {
+    return sb.from('exercises').select('id,user_id,name,muscle_group,equipment,description')
+      .order('name').then(function (r) {
+        state.exercises = r.data || [];
+        state.exById = {};
+        state.exercises.forEach(function (e) { state.exById[e.id] = e; });
+      });
+  }
+  function listTemplates() {
+    return sb.from('templates').select('id,name,phase,template_exercises(count)')
+      .order('created_at').then(function (r) { return r.data || []; });
+  }
+  function getTemplate(id) {
+    return sb.from('templates')
+      .select('id,name,phase,template_exercises(id,section,position,target_sets,target_reps,target_rest,exercise_id)')
+      .eq('id', id).single().then(function (r) {
+        var t = r.data;
+        if (t && t.template_exercises) t.template_exercises.sort(function (a, b) { return a.position - b.position; });
+        return t;
+      });
+  }
+  function inProgressSession() {
+    return sb.from('sessions').select('id,performed_on,template_id,templates(name)')
+      .is('finished_at', null).order('started_at', { ascending: false }).limit(1)
+      .then(function (r) { return (r.data && r.data[0]) || null; });
+  }
+  function lastTimeFor(exId) {
+    return sb.from('sessions')
+      .select('performed_on,set_logs!inner(set_number,weight,reps,exercise_id)')
+      .not('finished_at', 'is', null)
+      .eq('set_logs.exercise_id', exId)
+      .order('performed_on', { ascending: false }).limit(1)
+      .then(function (r) {
+        var s = r.data && r.data[0];
+        if (!s) return { date: null, byNum: {} };
+        var byNum = {};
+        (s.set_logs || []).forEach(function (sl) { byNum[sl.set_number] = sl; });
+        return { date: s.performed_on, byNum: byNum };
+      });
   }
 
-  // ---- exercise datalist / picker -----------------------------------------
-  function refreshExerciseOptions() {
-    knownExercises.sort(function (a, b) { return a.localeCompare(b); });
-    var dl = $("exercise-options");
-    dl.innerHTML = "";
-    knownExercises.forEach(function (name) {
-      var o = document.createElement("option");
-      o.value = name;
-      dl.appendChild(o);
+  /* ----------------------------------------------------------------------- *
+   * Boot
+   * ----------------------------------------------------------------------- */
+  function boot() {
+    if (!configured()) { show('view-setup'); return; }
+    if (!window.supabase) { show('view-setup'); return; }
+    sb = window.supabase.createClient(cfg.SUPABASE_URL, cfg.SUPABASE_ANON_KEY);
+    wireAuth(); setAuthMode('signin'); wireApp();
+
+    sb.auth.onAuthStateChange(function (_evt, session) {
+      var u = session && session.user;
+      if (u && (!state.user || state.user.id !== u.id)) { state.user = u; enterApp(); }
+      else if (!u && state.user) { state.user = null; show('view-auth'); }
+    });
+    sb.auth.getSession().then(function (r) {
+      var u = r.data && r.data.session && r.data.session.user;
+      if (u) { state.user = u; enterApp(); } else { show('view-auth'); }
     });
   }
 
-  function rememberExercise(name) {
-    name = (name || "").trim();
-    if (name && knownExercises.indexOf(name) === -1) {
-      knownExercises.push(name);
-      refreshExerciseOptions();
-    }
+  function enterApp() {
+    show('view-app');
+    Promise.all([ensureProfile(), loadExercises()]).then(function () {
+      return ensureStarters();
+    }).then(function () {
+      switchTab('templates');
+      renderTemplatesTab();
+    });
   }
 
-  // ---- "Log Session" set rows ---------------------------------------------
-  function addSetRow(prefill) {
-    prefill = prefill || {};
-    var container = $("sets-container");
-    var block = document.createElement("div");
-    block.className = "set-block";
-    block.innerHTML =
-      '<button class="remove" title="Remove">&times;</button>' +
-      '<div class="row" style="margin-bottom:8px">' +
-        '<input type="text" class="ex-name-input" list="exercise-options" placeholder="Exercise (e.g. Back Squat)">' +
-      '</div>' +
-      '<div class="grid-3">' +
-        '<input type="number" class="ex-weight" step="0.5" inputmode="decimal" placeholder="Weight">' +
-        '<input type="number" class="ex-reps" step="1" inputmode="numeric" placeholder="Reps">' +
-        '<input type="number" class="ex-setnum" step="1" inputmode="numeric" placeholder="Set #">' +
-      '</div>';
-    block.querySelector(".ex-name-input").value = prefill.exercise || "";
-    block.querySelector(".remove").addEventListener("click", function () {
-      if ($("sets-container").children.length > 1) block.remove();
-      else toast("Keep at least one set");
+  function ensureStarters() {
+    var flag = 'wl_seeded_' + state.user.id;
+    if (localStorage.getItem(flag)) return Promise.resolve();
+    return listTemplates().then(function (ts) {
+      localStorage.setItem(flag, '1');
+      if (ts.length) return;
+      return createStarterTemplates();
     });
-    block.querySelector(".ex-name-input").addEventListener("change", function () {
-      rememberExercise(this.value);
-    });
-    container.appendChild(block);
   }
-
-  function collectSets() {
-    var blocks = $("sets-container").querySelectorAll(".set-block");
-    var out = [];
-    blocks.forEach(function (b) {
-      var name = b.querySelector(".ex-name-input").value.trim();
-      if (!name) return;
-      var w = b.querySelector(".ex-weight").value;
-      var r = b.querySelector(".ex-reps").value;
-      var s = b.querySelector(".ex-setnum").value;
-      out.push({
-        exercise: name,
-        weight: w === "" ? null : Number(w),
-        reps: r === "" ? null : parseInt(r, 10),
-        set_number: s === "" ? null : parseInt(s, 10)
+  function createStarterTemplates() {
+    var chain = Promise.resolve();
+    STARTERS.forEach(function (tpl) {
+      chain = chain.then(function () {
+        return sb.from('templates').insert({ user_id: state.user.id, name: tpl.name, phase: tpl.phase })
+          .select('id').single().then(function (r) {
+            if (!r.data) return;
+            var rows = [];
+            tpl.items.forEach(function (it, i) {
+              var ex = state.exercises.filter(function (e) { return e.name === it.name; })[0];
+              if (!ex) return;
+              rows.push({
+                template_id: r.data.id, exercise_id: ex.id, user_id: state.user.id,
+                section: it.section, position: i + 1,
+                target_sets: M1.target_sets, target_reps: M1.target_reps, target_rest: M1.target_rest
+              });
+            });
+            if (rows.length) return sb.from('template_exercises').insert(rows);
+          });
       });
     });
-    return out;
+    return chain;
   }
 
-  function resetLogForm() {
-    $("sets-container").innerHTML = "";
-    addSetRow();
-    $("notes").value = "";
-    setRating(0);
-    $("performed_at").value = localDatetimeValue(new Date());
-    $("save-err").textContent = "";
+  /* ----------------------------------------------------------------------- *
+   * Tabs & top-level wiring
+   * ----------------------------------------------------------------------- */
+  function switchTab(tab) {
+    state.tab = tab;
+    ['templates', 'history', 'exercises'].forEach(function (t) {
+      $('tab-' + t).hidden = (t !== tab);
+    });
+    document.querySelectorAll('.tabbtn').forEach(function (b) {
+      b.setAttribute('aria-selected', b.getAttribute('data-tab') === tab ? 'true' : 'false');
+    });
+    if (tab === 'history') renderHistory();
+    if (tab === 'exercises') renderExercises();
+    if (tab === 'templates') renderTemplatesTab();
+    window.scrollTo(0, 0);
   }
 
-  // ---- rating stars --------------------------------------------------------
-  function setRating(v) {
-    currentRating = v;
-    var stars = $("rating-stars").querySelectorAll(".star");
-    stars.forEach(function (s) {
-      s.classList.toggle("on", Number(s.dataset.v) <= v);
+  function wireApp() {
+    document.querySelectorAll('.tabbtn').forEach(function (b) {
+      b.addEventListener('click', function () { switchTab(b.getAttribute('data-tab')); });
+    });
+    $('open-settings').addEventListener('click', openSettings);
+    $('freeform-btn').addEventListener('click', function () { startSession(null); });
+    $('new-template-btn').addEventListener('click', function () { openTemplateEditor(null); });
+    $('add-exercise-btn').addEventListener('click', openExerciseForm);
+    $('ex-search').addEventListener('input', renderExercises);
+
+    $('session-back').addEventListener('click', function () { overlay('view-session', false); renderTemplatesTab(); });
+    $('session-finish').addEventListener('click', finishActive);
+    $('progress-back').addEventListener('click', function () { overlay('view-progress', false); });
+    $('detail-back').addEventListener('click', function () { overlay('view-detail', false); });
+
+    var body = $('session-body');
+    body.addEventListener('click', onSessionClick);
+    body.addEventListener('change', onSessionInput);
+  }
+
+  /* ----------------------------------------------------------------------- *
+   * Templates tab (home)
+   * ----------------------------------------------------------------------- */
+  function renderTemplatesTab() {
+    inProgressSession().then(function (ip) {
+      var slot = $('resume-slot');
+      if (ip) {
+        slot.innerHTML =
+          '<div class="resume-banner"><div class="grow">Workout in progress' +
+          (ip.templates ? ' · ' + esc(ip.templates.name) : '') + '</div>' +
+          '<button id="resume-btn">Resume</button></div>';
+        $('resume-btn').addEventListener('click', function () { resumeSession(ip.id); });
+      } else { slot.innerHTML = ''; }
+    });
+    listTemplates().then(function (ts) {
+      var box = $('templates-list');
+      if (!ts.length) {
+        box.innerHTML = '<div class="empty"><div class="big">🗂️</div>No templates yet.<br>Create one, or start a freeform session.</div>';
+        return;
+      }
+      box.innerHTML = ts.map(function (t) {
+        var count = (t.template_exercises && t.template_exercises[0] && t.template_exercises[0].count) || 0;
+        return '<div class="card"><div class="row"><div class="grow">' +
+          '<div style="font-size:19px;font-weight:700">' + esc(t.name) + '</div>' +
+          '<div class="muted" style="font-size:14px;margin-top:3px">' +
+          (t.phase ? '<span class="pill">' + esc(t.phase) + '</span> &nbsp;' : '') +
+          count + ' exercise' + (count === 1 ? '' : 's') + '</div></div>' +
+          '<button class="iconbtn" data-edit="' + t.id + '" title="Edit">✏️</button></div>' +
+          '<div style="margin-top:12px"><button class="btn" data-start="' + t.id + '">Start workout</button></div></div>';
+      }).join('');
+      box.querySelectorAll('[data-start]').forEach(function (b) {
+        b.addEventListener('click', function () { startSession(+b.getAttribute('data-start')); });
+      });
+      box.querySelectorAll('[data-edit]').forEach(function (b) {
+        b.addEventListener('click', function () { openTemplateEditor(+b.getAttribute('data-edit')); });
+      });
     });
   }
 
-  // ---- save ----------------------------------------------------------------
-  function saveSession() {
-    var sets = collectSets();
-    $("save-err").textContent = "";
-    if (sets.length === 0) {
-      $("save-err").textContent = "Add at least one exercise with a name.";
+  /* ----------------------------------------------------------------------- *
+   * Active session
+   * ----------------------------------------------------------------------- */
+  // Build the in-memory model: list of { exId, name, section, target, sets:[{set_number,weight,reps,completed,saved}], last:{date,byNum} }
+  function startSession(templateId) {
+    var p = templateId
+      ? getTemplate(templateId)
+      : Promise.resolve(null);
+    p.then(function (tpl) {
+      return sb.from('sessions').insert({
+        user_id: state.user.id, template_id: templateId || null
+      }).select('id,performed_on,template_id').single().then(function (r) {
+        return buildActive(r.data, tpl, []);
+      });
+    }).then(openActive);
+  }
+
+  function resumeSession(sessionId) {
+    sb.from('sessions').select('id,performed_on,template_id,templates(name)')
+      .eq('id', sessionId).single().then(function (r) {
+        var s = r.data;
+        var tplP = s.template_id ? getTemplate(s.template_id) : Promise.resolve(null);
+        var logsP = sb.from('set_logs').select('exercise_id,set_number,weight,reps,completed').eq('session_id', sessionId);
+        return Promise.all([tplP, logsP]).then(function (res) {
+          return buildActive(s, res[0], (res[1].data || []));
+        });
+      }).then(openActive);
+  }
+
+  function buildActive(session, tpl, existingLogs) {
+    var exList = [];
+    var logsBy = {}; // exId -> {setn -> log}
+    existingLogs.forEach(function (l) {
+      (logsBy[l.exercise_id] = logsBy[l.exercise_id] || {})[l.set_number] = l;
+    });
+
+    function addExercise(exId, section, target) {
+      var ex = state.exById[exId] || { id: exId, name: 'Exercise' };
+      var nSets = target ? maxInt(target.target_sets, 3) : 3;
+      var saved = logsBy[exId] || {};
+      var maxSaved = Object.keys(saved).reduce(function (a, k) { return Math.max(a, +k); }, 0);
+      nSets = Math.max(nSets, maxSaved);
+      var sets = [];
+      for (var i = 1; i <= nSets; i++) {
+        var s = saved[i];
+        sets.push({ set_number: i,
+          weight: s && s.weight != null ? s.weight : '',
+          reps: s && s.reps != null ? s.reps : '',
+          completed: !!(s && s.completed) });
+      }
+      exList.push({ exId: exId, name: ex.name, section: section || null, target: target || null,
+        rest: target ? restSeconds(target.target_rest) : 0, sets: sets, last: { date: null, byNum: {} } });
+    }
+
+    if (tpl && tpl.template_exercises) {
+      tpl.template_exercises.forEach(function (te) {
+        addExercise(te.exercise_id, te.section, te);
+      });
+    } else {
+      // freeform: seed from any existing logs (resume), else empty
+      Object.keys(logsBy).forEach(function (exId) { addExercise(+exId, null, null); });
+    }
+
+    var model = { session: session, tpl: tpl, exercises: exList };
+    // load last-time hints in parallel (non-blocking refresh)
+    var ids = exList.map(function (e) { return e.exId; });
+    Promise.all(ids.map(function (id) { return lastTimeFor(id); })).then(function (res) {
+      res.forEach(function (lt, i) { exList[i].last = lt; });
+      if (state.active === model) renderActive();
+    });
+    return model;
+  }
+
+  function openActive(model) {
+    state.active = model;
+    var s = model.session;
+    $('session-title').textContent = model.tpl ? model.tpl.name : 'Freeform session';
+    $('session-sub').textContent = fmtDateFull(s.performed_on);
+    overlay('view-session', true);
+    window.scrollTo(0, 0);
+    renderActive();
+  }
+
+  function renderActive() {
+    var m = state.active; if (!m) return;
+    var html = '';
+    var lastSection = '__none__';
+    m.exercises.forEach(function (ex, idx) {
+      if (ex.section && ex.section !== lastSection) {
+        html += '<div class="section-head">' + esc(ex.section) + '</div>';
+        lastSection = ex.section;
+      } else if (!ex.section && lastSection !== '__none__') {
+        lastSection = '__none__';
+      }
+      html += exerciseCardHtml(ex, idx);
+    });
+    html += '<div style="margin-top:6px"><button class="btn secondary" id="session-add-ex">+ Add exercise</button></div>';
+    if (m.session.notes != null || true) {
+      html += '<label class="field" style="margin-top:16px"><span>Session notes</span>' +
+        '<textarea id="session-notes" rows="2" placeholder="How did it feel?">' + esc(m.session.notes || '') + '</textarea></label>';
+    }
+    var body = $('session-body');
+    body.innerHTML = html;
+    $('session-add-ex').addEventListener('click', function () {
+      pickExercise(function (ex) { addExerciseToActive(ex); });
+    });
+    var notes = $('session-notes');
+    if (notes) notes.addEventListener('change', function () {
+      m.session.notes = notes.value;
+      sb.from('sessions').update({ notes: notes.value }).eq('id', m.session.id);
+    });
+  }
+
+  function exerciseCardHtml(ex, idx) {
+    var allset = ex.sets.length > 0 && ex.sets.every(function (s) { return s.completed; });
+    var target = ex.target ? (ex.target.target_sets || '?') + ' × ' + (ex.target.target_reps || '?') : '';
+    var rows = ex.sets.map(function (s) { return setRowHtml(idx, s, ex.last.byNum[s.set_number]); }).join('');
+    return '<div class="ex-card' + (allset ? ' allset' : '') + '" data-card="' + idx + '">' +
+      '<div class="row"><div class="grow"><div class="exname">' + esc(ex.name) + '</div>' +
+      (target ? '<div class="extarget">Target ' + esc(target) + (ex.target.target_rest ? ' · rest ' + esc(ex.target.target_rest) : '') + '</div>' : '') +
+      '</div><button class="iconbtn" data-prog="' + ex.exId + '" title="Progress">📈</button></div>' +
+      rows +
+      '<div style="margin-top:8px"><button class="btn ghost" data-addset="' + idx + '">+ Add set</button></div>' +
+      '</div>';
+  }
+
+  function setRowHtml(exIdx, s, last) {
+    var hint = last ? ('last: ' + fmtW(last.weight) + (last.reps != null ? ' × ' + last.reps : '')) : '';
+    var beat = (last && s.weight !== '' && s.weight != null && Number(s.weight) > Number(last.weight));
+    var w = (s.weight === '' || s.weight == null) ? '' : s.weight;
+    var r = (s.reps === '' || s.reps == null) ? '' : s.reps;
+    return '<div class="lasthint">' + (hint ? esc(hint) + (beat ? ' <span class="beat">▲ PR</span>' : '') : '') + '</div>' +
+      '<div class="setrow" data-ex="' + exIdx + '" data-setn="' + s.set_number + '">' +
+        '<div class="setn num">' + s.set_number + '</div>' +
+        '<div class="cell"><span class="steplabel">Weight (' + unit() + ')</span>' +
+          '<div class="stepper"><button data-act="w-" aria-label="decrease weight">−</button>' +
+          '<input data-f="weight" inputmode="decimal" value="' + esc(w) + '" />' +
+          '<button data-act="w+" aria-label="increase weight">+</button></div></div>' +
+        '<div class="cell"><span class="steplabel">Reps</span>' +
+          '<div class="stepper"><button data-act="r-" aria-label="decrease reps">−</button>' +
+          '<input data-f="reps" inputmode="numeric" value="' + esc(r) + '" />' +
+          '<button data-act="r+" aria-label="increase reps">+</button></div></div>' +
+        '<div class="donebox' + (s.completed ? ' on' : '') + '" data-act="done" role="checkbox" aria-checked="' +
+          (s.completed ? 'true' : 'false') + '" tabindex="0">✓</div>' +
+      '</div>';
+  }
+
+  function activeSet(exIdx, setn) {
+    var ex = state.active.exercises[exIdx];
+    for (var i = 0; i < ex.sets.length; i++) if (ex.sets[i].set_number === setn) return { ex: ex, s: ex.sets[i] };
+    return null;
+  }
+
+  function onSessionClick(e) {
+    var prog = e.target.closest('[data-prog]');
+    if (prog) { openProgress(+prog.getAttribute('data-prog')); return; }
+    var addset = e.target.closest('[data-addset]');
+    if (addset) { addSetTo(+addset.getAttribute('data-addset')); return; }
+    var act = e.target.closest('[data-act]');
+    if (!act) return;
+    var row = act.closest('.setrow'); if (!row) return;
+    var exIdx = +row.getAttribute('data-ex'), setn = +row.getAttribute('data-setn');
+    var ref = activeSet(exIdx, setn); if (!ref) return;
+    var kind = act.getAttribute('data-act');
+    if (kind === 'done') {
+      ref.s.completed = !ref.s.completed;
+      act.classList.toggle('on', ref.s.completed);
+      act.setAttribute('aria-checked', ref.s.completed ? 'true' : 'false');
+      refreshCardState(exIdx);
+      saveSet(ref.ex, ref.s);
+      if (ref.s.completed && ref.ex.rest) startRest(ref.ex.rest, ref.ex.name);
       return;
     }
-    var btn = $("btn-save");
-    btn.disabled = true; btn.textContent = "Saving…";
-
-    var performedAt = $("performed_at").value
-      ? new Date($("performed_at").value).toISOString()
-      : new Date().toISOString();
-
-    sb.from("sessions").insert({
-      performed_at: performedAt,
-      rating: currentRating || null,
-      notes: $("notes").value.trim() || null
-    }).select().single().then(function (res) {
-      if (res.error) throw res.error;
-      var sessionId = res.data.id;
-      var rows = sets.map(function (s) {
-        return {
-          session_id: sessionId,
-          exercise: s.exercise,
-          weight: s.weight,
-          reps: s.reps,
-          set_number: s.set_number
-        };
-      });
-      return sb.from("exercise_sets").insert(rows);
-    }).then(function (res) {
-      if (res && res.error) throw res.error;
-      sets.forEach(function (s) { rememberExercise(s.exercise); });
-      toast("Session saved 💪");
-      resetLogForm();
-    }).catch(function (err) {
-      $("save-err").textContent = err.message || "Could not save. Try again.";
-    }).finally(function () {
-      btn.disabled = false; btn.textContent = "Save Session";
-    });
-  }
-
-  // ---- history -------------------------------------------------------------
-  function loadHistory() {
-    var el = $("history-list");
-    el.innerHTML = '<div class="empty">Loading…</div>';
-    sb.from("sessions")
-      .select("id, performed_at, rating, notes, exercise_sets ( exercise, weight, reps, set_number )")
-      .order("performed_at", { ascending: false })
-      .limit(200)
-      .then(function (res) {
-        if (res.error) { el.innerHTML = '<div class="empty">' + res.error.message + "</div>"; return; }
-        var sessions = res.data || [];
-        if (!sessions.length) {
-          el.innerHTML = '<div class="empty">No sessions yet. Log your first one!</div>';
-          return;
-        }
-        // collect exercises seen for the picker datalist
-        sessions.forEach(function (s) {
-          (s.exercise_sets || []).forEach(function (x) { rememberExercise(x.exercise); });
-        });
-        el.innerHTML = "";
-        sessions.forEach(function (s) {
-          el.appendChild(renderSessionCard(s));
-        });
-      });
-  }
-
-  function renderSessionCard(s) {
-    var card = document.createElement("div");
-    card.className = "session-card";
-    var stars = s.rating ? "★★★★★".slice(0, s.rating) + "☆☆☆☆☆".slice(0, 5 - s.rating) : "";
-    var head = '<div class="sc-head">' +
-      '<span class="sc-date">' + fmtDate(s.performed_at) +
-      ' <span class="sc-time">· ' + fmtTime(s.performed_at) + "</span></span>" +
-      '<span class="sc-rating">' + stars + "</span></div>";
-    var notes = s.notes ? '<div class="sc-notes">“' + escapeHtml(s.notes) + "”</div>" : "";
-    var lines = (s.exercise_sets || []).map(function (x) {
-      var detail = [];
-      if (x.weight != null) detail.push(x.weight);
-      if (x.reps != null) detail.push("× " + x.reps);
-      var setLbl = x.set_number != null ? '<span class="muted">set ' + x.set_number + "</span> " : "";
-      return '<div class="ex-line"><span class="ex-name">' + escapeHtml(x.exercise) +
-        '</span><span class="ex-detail">' + setLbl + detail.join(" ") + "</span></div>";
-    }).join("");
-    var del = '<div style="text-align:right;margin-top:8px">' +
-      '<button class="add-link" style="color:#b91c1c" data-del="' + s.id + '">Delete</button></div>';
-    card.innerHTML = head + notes + lines + del;
-    card.querySelector("[data-del]").addEventListener("click", function () {
-      if (!confirm("Delete this whole session?")) return;
-      sb.from("sessions").delete().eq("id", s.id).then(function (res) {
-        if (res.error) { toast(res.error.message); return; }
-        card.remove();
-        toast("Deleted");
-      });
-    });
-    return card;
-  }
-
-  // ---- by exercise ---------------------------------------------------------
-  function populateExercisePicker() {
-    var sel = $("ex-picker");
-    var prev = sel.value;
-    sel.innerHTML = "";
-    knownExercises.forEach(function (name) {
-      var o = document.createElement("option");
-      o.value = name; o.textContent = name;
-      sel.appendChild(o);
-    });
-    if (prev && knownExercises.indexOf(prev) !== -1) sel.value = prev;
-  }
-
-  function loadExerciseHistory(name) {
-    var statsEl = $("ex-stats");
-    var histEl = $("ex-history");
-    histEl.innerHTML = '<div class="empty">Loading…</div>';
-    statsEl.innerHTML = "";
-    sb.from("exercise_sets")
-      .select("weight, reps, set_number, sessions!inner ( performed_at )")
-      .eq("exercise", name)
-      .then(function (res) {
-        if (res.error) { histEl.innerHTML = '<div class="empty">' + res.error.message + "</div>"; return; }
-        var rows = (res.data || []).map(function (r) {
-          return {
-            performed_at: r.sessions.performed_at,
-            weight: r.weight, reps: r.reps, set_number: r.set_number
-          };
-        });
-        rows.sort(function (a, b) { return new Date(b.performed_at) - new Date(a.performed_at); });
-        if (!rows.length) {
-          histEl.innerHTML = '<div class="empty">No history for ' + escapeHtml(name) + " yet.</div>";
-          return;
-        }
-        var maxW = rows.reduce(function (m, r) { return r.weight != null && r.weight > m ? r.weight : m; }, -Infinity);
-        if (maxW === -Infinity) maxW = null;
-        var totalSets = rows.length;
-        var lastDate = rows[0].performed_at;
-        statsEl.innerHTML =
-          '<div class="stat-strip">' +
-            '<div class="stat"><div class="v">' + (maxW != null ? maxW : "–") + '</div><div class="k">Best weight</div></div>' +
-            '<div class="stat"><div class="v">' + totalSets + '</div><div class="k">Sets logged</div></div>' +
-            '<div class="stat"><div class="v">' + fmtDate(lastDate).replace(/,.*/, "") + '</div><div class="k">Last done</div></div>' +
-          "</div>";
-        var body = rows.map(function (r) {
-          var isPr = maxW != null && r.weight === maxW;
-          return "<tr><td>" + fmtDate(r.performed_at) + "</td>" +
-            '<td class="num">' + (r.weight != null ? r.weight : "–") +
-            (isPr ? '<span class="pr-badge">PR</span>' : "") + "</td>" +
-            '<td class="num">' + (r.reps != null ? r.reps : "–") + "</td></tr>";
-        }).join("");
-        histEl.innerHTML =
-          '<table class="hist-table"><thead><tr><th>Date</th><th>Weight</th><th>Reps</th></tr></thead>' +
-          "<tbody>" + body + "</tbody></table>";
-      });
-  }
-
-  function escapeHtml(s) {
-    return String(s).replace(/[&<>"']/g, function (c) {
-      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
-    });
-  }
-
-  // ---- tabs ----------------------------------------------------------------
-  function activateTab(name) {
-    document.querySelectorAll(".tab").forEach(function (t) {
-      t.classList.toggle("active", t.dataset.tab === name);
-    });
-    ["log", "history", "exercise"].forEach(function (n) {
-      $("tab-" + n).classList.toggle("hidden", n !== name);
-    });
-    if (name === "history") loadHistory();
-    if (name === "exercise") {
-      populateExercisePicker();
-      if ($("ex-picker").value) loadExerciseHistory($("ex-picker").value);
+    // steppers
+    var input = row.querySelector(kind[0] === 'w' ? '[data-f="weight"]' : '[data-f="reps"]');
+    if (kind === 'w-' || kind === 'w+') {
+      var cur = parseFloat(input.value) || 0;
+      cur = Math.max(0, Math.round((cur + (kind === 'w+' ? wStep() : -wStep())) * 100) / 100);
+      input.value = cur; ref.s.weight = cur;
+    } else {
+      var cr = parseInt(input.value, 10) || 0;
+      cr = Math.max(0, cr + (kind === 'r+' ? 1 : -1));
+      input.value = cr; ref.s.reps = cr;
     }
+    refreshHint(row, ref);
+    saveSetDebounced(ref.ex, ref.s);
   }
 
-  // ---- auth ----------------------------------------------------------------
-  var signupMode = false;
+  function onSessionInput(e) {
+    var input = e.target.closest('[data-f]'); if (!input) return;
+    var row = input.closest('.setrow'); if (!row) return;
+    var exIdx = +row.getAttribute('data-ex'), setn = +row.getAttribute('data-setn');
+    var ref = activeSet(exIdx, setn); if (!ref) return;
+    var f = input.getAttribute('data-f');
+    var val = input.value.trim();
+    if (f === 'weight') ref.s.weight = (val === '' ? '' : (parseFloat(val) || 0));
+    else ref.s.reps = (val === '' ? '' : (parseInt(val, 10) || 0));
+    refreshHint(row, ref);
+    saveSet(ref.ex, ref.s);
+  }
 
-  function doAuth() {
-    var email = $("email").value.trim();
-    var password = $("password").value;
-    $("auth-err").textContent = "";
-    if (!email || !password) { $("auth-err").textContent = "Enter email and password."; return; }
-    var btn = $("btn-login");
-    btn.disabled = true; btn.textContent = "…";
-    var p = signupMode
-      ? sb.auth.signUp({ email: email, password: password })
-      : sb.auth.signInWithPassword({ email: email, password: password });
-    p.then(function (res) {
-      if (res.error) { $("auth-err").textContent = res.error.message; return; }
-      if (signupMode && !res.data.session) {
-        $("auth-err").textContent = "Account created. Check your email to confirm, then sign in.";
-        setSignupMode(false);
-      }
-      // onAuthStateChange handles the success path.
-    }).finally(function () {
-      btn.disabled = false; btn.textContent = signupMode ? "Sign Up" : "Sign In";
+  function refreshHint(row, ref) {
+    var last = ref.ex.last.byNum[ref.s.set_number];
+    var hintEl = row.previousElementSibling;
+    if (!hintEl || !hintEl.classList.contains('lasthint')) return;
+    if (!last) { hintEl.innerHTML = ''; return; }
+    var beat = ref.s.weight !== '' && ref.s.weight != null && Number(ref.s.weight) > Number(last.weight);
+    hintEl.innerHTML = esc('last: ' + fmtW(last.weight) + (last.reps != null ? ' × ' + last.reps : '')) +
+      (beat ? ' <span class="beat">▲ PR</span>' : '');
+  }
+
+  function refreshCardState(exIdx) {
+    var ex = state.active.exercises[exIdx];
+    var card = document.querySelector('.ex-card[data-card="' + exIdx + '"]');
+    if (!card) return;
+    var allset = ex.sets.length > 0 && ex.sets.every(function (s) { return s.completed; });
+    card.classList.toggle('allset', allset);
+  }
+
+  function addSetTo(exIdx) {
+    var ex = state.active.exercises[exIdx];
+    var n = ex.sets.length ? ex.sets[ex.sets.length - 1].set_number + 1 : 1;
+    ex.sets.push({ set_number: n, weight: '', reps: '', completed: false });
+    renderActive();
+  }
+
+  function addExerciseToActive(ex) {
+    var m = state.active;
+    // skip if already present
+    if (m.exercises.some(function (e) { return e.exId === ex.id; })) return;
+    m.exercises.push({ exId: ex.id, name: ex.name, section: null, target: null, rest: 0,
+      sets: [{ set_number: 1, weight: '', reps: '', completed: false },
+             { set_number: 2, weight: '', reps: '', completed: false },
+             { set_number: 3, weight: '', reps: '', completed: false }],
+      last: { date: null, byNum: {} } });
+    lastTimeFor(ex.id).then(function (lt) {
+      var added = m.exercises[m.exercises.length - 1];
+      if (added) added.last = lt;
+      if (state.active === m) renderActive();
+    });
+    renderActive();
+  }
+
+  function saveSet(ex, s) {
+    if (!state.active) return;
+    var hasData = (s.weight !== '' && s.weight != null) || (s.reps !== '' && s.reps != null) || s.completed;
+    if (!hasData) return; // don't write empty rows
+    sb.from('set_logs').upsert({
+      session_id: state.active.session.id,
+      exercise_id: ex.exId,
+      user_id: state.user.id,
+      set_number: s.set_number,
+      weight: (s.weight === '' ? null : s.weight),
+      reps: (s.reps === '' ? null : s.reps),
+      completed: !!s.completed
+    }, { onConflict: 'session_id,exercise_id,set_number' }).then(function (r) {
+      if (r.error) console.warn('save set failed', r.error.message);
     });
   }
+  var saveSetDebounced = debounce(function (ex, s) { saveSet(ex, s); }, 450);
 
-  function setSignupMode(on) {
-    signupMode = on;
-    $("btn-login").textContent = on ? "Sign Up" : "Sign In";
-    $("toggle-signup").textContent = on ? "Have an account? Sign in" : "Need an account? Sign up";
-    $("password").setAttribute("autocomplete", on ? "new-password" : "current-password");
+  function finishActive() {
+    var m = state.active; if (!m) return;
+    sb.from('sessions').update({ finished_at: new Date().toISOString(), notes: m.session.notes || null })
+      .eq('id', m.session.id).then(function () {
+        stopRest();
+        state.active = null;
+        overlay('view-session', false);
+        switchTab('history');
+      });
   }
 
-  function enterApp(session) {
-    $("who").textContent = session.user.email;
-    show("view-app");
-    resetLogForm();
-    refreshExerciseOptions();
-    activateTab("log");
+  /* ---- Rest timer ---- */
+  var restState = { id: null, left: 0 };
+  function startRest(seconds, name) {
+    stopRest();
+    restState.left = seconds;
+    var box = document.createElement('div');
+    box.className = 'resttimer'; box.id = 'resttimer';
+    document.body.appendChild(box);
+    function paint() {
+      var mm = Math.floor(restState.left / 60), ss = restState.left % 60;
+      box.innerHTML = '<span>⏱ ' + mm + ':' + (ss < 10 ? '0' : '') + ss + '</span>' +
+        '<button id="rest-skip">Skip</button>';
+      $('rest-skip').addEventListener('click', stopRest);
+    }
+    paint();
+    restState.id = setInterval(function () {
+      restState.left--; if (restState.left <= 0) { stopRest(); return; } paint();
+    }, 1000);
+  }
+  function stopRest() {
+    if (restState.id) { clearInterval(restState.id); restState.id = null; }
+    var b = $('resttimer'); if (b) b.remove();
   }
 
-  // ---- init ----------------------------------------------------------------
-  function init() {
-    if (!isConfigured()) { show("view-setup"); return; }
-    if (!window.supabase) { show("view-setup"); return; }
+  /* ----------------------------------------------------------------------- *
+   * History
+   * ----------------------------------------------------------------------- */
+  function renderHistory() {
+    var box = $('history-list');
+    box.innerHTML = '<div class="empty">Loading…</div>';
+    sb.from('sessions')
+      .select('id,performed_on,finished_at,templates(name),set_logs(exercise_id)')
+      .not('finished_at', 'is', null)
+      .order('performed_on', { ascending: false })
+      .then(function (r) {
+        var rows = r.data || [];
+        if (!rows.length) {
+          box.innerHTML = '<div class="empty"><div class="big">📅</div>No finished workouts yet.<br>Start one from the Workouts tab.</div>';
+          return;
+        }
+        var html = '', curMonth = '';
+        rows.forEach(function (s) {
+          var ml = monthLabel(s.performed_on);
+          if (ml !== curMonth) { html += '<div class="section-head">' + esc(ml) + '</div>'; curMonth = ml; }
+          var exCount = {}, setCount = (s.set_logs || []).length;
+          (s.set_logs || []).forEach(function (sl) { exCount[sl.exercise_id] = 1; });
+          var nEx = Object.keys(exCount).length;
+          html += '<button class="card tap" data-detail="' + s.id + '"><div class="row"><div class="grow">' +
+            '<div style="font-weight:700">' + fmtDate(s.performed_on) +
+            (s.templates ? ' · ' + esc(s.templates.name) : ' · Freeform') + '</div>' +
+            '<div class="muted" style="font-size:14px;margin-top:2px">' + nEx + ' exercise' + (nEx === 1 ? '' : 's') +
+            ', ' + setCount + ' set' + (setCount === 1 ? '' : 's') + '</div></div><div class="faint">›</div></div></button>';
+        });
+        box.innerHTML = html;
+        box.querySelectorAll('[data-detail]').forEach(function (b) {
+          b.addEventListener('click', function () { openDetail(+b.getAttribute('data-detail')); });
+        });
+      });
+  }
 
-    sb = window.supabase.createClient(cfg.SUPABASE_URL, cfg.SUPABASE_ANON_KEY);
+  function openDetail(id) {
+    overlay('view-detail', true);
+    var body = $('detail-body'); body.innerHTML = '<div class="empty">Loading…</div>';
+    sb.from('sessions')
+      .select('performed_on,notes,templates(name),set_logs(exercise_id,set_number,weight,reps,completed)')
+      .eq('id', id).single().then(function (r) {
+        var s = r.data;
+        $('detail-title').textContent = s.templates ? s.templates.name : 'Freeform session';
+        $('detail-sub').textContent = fmtDateFull(s.performed_on);
+        var byEx = {};
+        (s.set_logs || []).forEach(function (sl) { (byEx[sl.exercise_id] = byEx[sl.exercise_id] || []).push(sl); });
+        var html = '';
+        Object.keys(byEx).forEach(function (exId) {
+          var ex = state.exById[exId] || { name: 'Exercise' };
+          var sets = byEx[exId].sort(function (a, b) { return a.set_number - b.set_number; });
+          html += '<div class="ex-card"><div class="exname" style="margin-bottom:8px">' + esc(ex.name) + '</div>' +
+            sets.map(function (st) {
+              return '<div class="row" style="padding:4px 0"><div class="setn num" style="width:24px">' + st.set_number + '</div>' +
+                '<div class="grow num">' + fmtW(st.weight) + ' ' + unit() + ' × ' + (st.reps != null ? st.reps : '–') + '</div>' +
+                (st.completed ? '<span class="pill">done</span>' : '<span class="faint">skipped</span>') + '</div>';
+            }).join('') + '</div>';
+        });
+        if (s.notes) html += '<div class="card"><div class="muted" style="font-size:13px;text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Notes</div>' + esc(s.notes) + '</div>';
+        body.innerHTML = html || '<div class="empty">No sets logged.</div>';
+      });
+  }
 
-    // wire events
-    $("btn-login").addEventListener("click", doAuth);
-    $("password").addEventListener("keydown", function (e) { if (e.key === "Enter") doAuth(); });
-    $("toggle-signup").addEventListener("click", function () { setSignupMode(!signupMode); });
-    $("btn-logout").addEventListener("click", function () { sb.auth.signOut(); });
-    $("add-set").addEventListener("click", function () { addSetRow(); });
-    $("btn-save").addEventListener("click", saveSession);
-    $("rating-stars").querySelectorAll(".star").forEach(function (s) {
-      s.addEventListener("click", function () {
-        var v = Number(s.dataset.v);
-        setRating(v === currentRating ? 0 : v); // click same star again to clear
+  /* ----------------------------------------------------------------------- *
+   * Exercise progress
+   * ----------------------------------------------------------------------- */
+  function openProgress(exId) {
+    overlay('view-progress', true);
+    var ex = state.exById[exId] || { name: 'Exercise' };
+    $('progress-title').textContent = ex.name;
+    $('progress-sub').textContent = ex.muscle_group || '';
+    var body = $('progress-body'); body.innerHTML = '<div class="empty">Loading…</div>';
+    sb.from('sessions')
+      .select('performed_on,set_logs!inner(weight,reps,exercise_id)')
+      .not('finished_at', 'is', null)
+      .eq('set_logs.exercise_id', exId)
+      .order('performed_on', { ascending: true })
+      .then(function (r) {
+        var sessions = r.data || [];
+        var points = sessions.map(function (s) {
+          var top = 0, vol = 0;
+          (s.set_logs || []).forEach(function (sl) {
+            var w = Number(sl.weight) || 0, reps = Number(sl.reps) || 0;
+            if (w > top) top = w; vol += w * reps;
+          });
+          return { date: s.performed_on, top: top, vol: vol };
+        });
+        if (!points.length) { body.innerHTML = '<div class="empty"><div class="big">📈</div>No finished sets for this exercise yet.</div>'; return; }
+        var best = points.reduce(function (a, p) { return Math.max(a, p.top); }, 0);
+        var lastP = points[points.length - 1];
+        var html = '<div class="stat-row">' +
+          '<div class="stat"><div class="k">Best</div><div class="v num">' + fmtW(best) + ' ' + unit() + '</div></div>' +
+          '<div class="stat"><div class="k">Last</div><div class="v num">' + fmtW(lastP.top) + ' ' + unit() + '</div></div>' +
+          '<div class="stat"><div class="k">Sessions</div><div class="v num">' + points.length + '</div></div></div>';
+        html += '<div class="chartwrap"><h3>Top set weight (' + unit() + ')</h3>' + lineChart(points.map(function (p) { return { x: p.date, y: p.top }; })) + '</div>';
+        html += '<div class="chartwrap"><h3>Volume (weight × reps)</h3>' + lineChart(points.map(function (p) { return { x: p.date, y: p.vol }; })) + '</div>';
+        html += '<div class="section-head">History</div>';
+        html += points.slice().reverse().map(function (p) {
+          return '<div class="card"><div class="row"><div class="grow">' + fmtDate(p.date) + '</div>' +
+            '<div class="num">' + fmtW(p.top) + ' ' + unit() + ' top · ' + Math.round(p.vol) + ' vol</div></div></div>';
+        }).join('');
+        body.innerHTML = html;
+      });
+  }
+
+  function lineChart(data) {
+    var W = 320, H = 150, pad = 8, padB = 22;
+    if (data.length === 1) data = [{ x: data[0].x, y: data[0].y }, { x: data[0].x, y: data[0].y }];
+    var ys = data.map(function (d) { return d.y; });
+    var maxY = Math.max.apply(null, ys), minY = Math.min.apply(null, ys);
+    if (maxY === minY) { maxY = maxY + 1; minY = Math.max(0, minY - 1); }
+    var n = data.length;
+    function px(i) { return pad + (i / (n - 1)) * (W - pad * 2); }
+    function py(v) { return pad + (1 - (v - minY) / (maxY - minY)) * (H - pad - padB); }
+    var d = '', dots = '';
+    data.forEach(function (p, i) {
+      d += (i === 0 ? 'M' : 'L') + px(i).toFixed(1) + ' ' + py(p.y).toFixed(1) + ' ';
+      dots += '<circle cx="' + px(i).toFixed(1) + '" cy="' + py(p.y).toFixed(1) + '" r="3" fill="#2f855a"/>';
+    });
+    var area = d + 'L' + px(n - 1).toFixed(1) + ' ' + (H - padB) + ' L' + px(0).toFixed(1) + ' ' + (H - padB) + ' Z';
+    var firstLbl = '<text x="' + pad + '" y="' + (H - 6) + '" font-size="11" fill="#9aa3ab">' + fmtDate(data[0].x) + '</text>';
+    var lastLbl = '<text x="' + (W - pad) + '" y="' + (H - 6) + '" font-size="11" fill="#9aa3ab" text-anchor="end">' + fmtDate(data[n - 1].x) + '</text>';
+    return '<svg class="chart" viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="none">' +
+      '<path d="' + area + '" fill="#e6f2ec"/>' +
+      '<path d="' + d + '" fill="none" stroke="#2f855a" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>' +
+      dots + firstLbl + lastLbl + '</svg>';
+  }
+
+  /* ----------------------------------------------------------------------- *
+   * Exercises library
+   * ----------------------------------------------------------------------- */
+  function renderExercises() {
+    var q = ($('ex-search').value || '').toLowerCase().trim();
+    var box = $('exercises-list');
+    var list = state.exercises.filter(function (e) {
+      return !q || e.name.toLowerCase().indexOf(q) !== -1 || (e.muscle_group || '').toLowerCase().indexOf(q) !== -1;
+    });
+    if (!list.length) { box.innerHTML = '<div class="empty">No exercises match.</div>'; return; }
+    var groups = {};
+    list.forEach(function (e) { (groups[e.muscle_group || 'Other'] = groups[e.muscle_group || 'Other'] || []).push(e); });
+    var html = '';
+    Object.keys(groups).sort().forEach(function (g) {
+      html += '<div class="section-head">' + esc(g) + '</div>';
+      groups[g].forEach(function (e) {
+        html += '<div class="card"><div class="row"><div class="grow"><div style="font-weight:650">' + esc(e.name) + '</div>' +
+          '<div class="muted" style="font-size:13px">' + esc(e.equipment || '') +
+          (e.user_id ? ' · <span class="faint">custom</span>' : '') + '</div></div>' +
+          '<button class="iconbtn" data-prog="' + e.id + '">📈</button></div>' +
+          (e.description ? '<div class="muted" style="font-size:14px;margin-top:8px">' + esc(e.description) + '</div>' : '') +
+          '</div>';
       });
     });
-    document.querySelectorAll(".tab").forEach(function (t) {
-      t.addEventListener("click", function () { activateTab(t.dataset.tab); });
-    });
-    $("ex-picker").addEventListener("change", function () { loadExerciseHistory(this.value); });
-
-    refreshExerciseOptions();
-
-    sb.auth.onAuthStateChange(function (_event, session) {
-      if (session) enterApp(session);
-      else { show("view-auth"); setSignupMode(false); }
-    });
-
-    sb.auth.getSession().then(function (res) {
-      if (res.data.session) enterApp(res.data.session);
-      else show("view-auth");
+    box.innerHTML = html;
+    box.querySelectorAll('[data-prog]').forEach(function (b) {
+      b.addEventListener('click', function () { openProgress(+b.getAttribute('data-prog')); });
     });
   }
 
-  document.addEventListener("DOMContentLoaded", init);
+  /* ----------------------------------------------------------------------- *
+   * Modals / sheets
+   * ----------------------------------------------------------------------- */
+  function openSheet(html) {
+    var root = $('modal-root');
+    root.innerHTML = '<div class="modal-back"><div class="sheet">' + html + '</div></div>';
+    var back = root.querySelector('.modal-back');
+    back.addEventListener('click', function (e) { if (e.target === back) closeSheet(); });
+    return root.querySelector('.sheet');
+  }
+  function closeSheet() { $('modal-root').innerHTML = ''; }
+
+  function openSettings() {
+    var u = unit();
+    var sheet = openSheet('<h2>Settings</h2>' +
+      '<label class="field"><span>Weight unit</span>' +
+      '<select id="set-unit"><option value="lb"' + (u === 'lb' ? ' selected' : '') + '>Pounds (lb)</option>' +
+      '<option value="kg"' + (u === 'kg' ? ' selected' : '') + '>Kilograms (kg)</option></select></label>' +
+      '<div class="muted" style="font-size:14px;margin-bottom:18px">Signed in as ' + esc(state.user.email || '') + '</div>' +
+      '<div class="stack"><button class="btn" id="set-save">Done</button>' +
+      '<button class="btn danger" id="set-signout">Sign out</button></div>');
+    sheet.querySelector('#set-unit').addEventListener('change', function (e) { setUnit(e.target.value); });
+    sheet.querySelector('#set-save').addEventListener('click', function () { closeSheet(); renderTemplatesTab(); });
+    sheet.querySelector('#set-signout').addEventListener('click', function () { closeSheet(); signOut(); });
+  }
+
+  var MUSCLES = ['Chest','Back','Shoulders','Biceps','Triceps','Legs','Glutes','Core','Cardio','Other'];
+  var EQUIP = ['Dumbbell','Barbell','Cable','Machine','Bodyweight','Kettlebell','Band','Other'];
+  function openExerciseForm() {
+    var sheet = openSheet('<h2>New exercise</h2>' +
+      '<label class="field"><span>Name</span><input id="nx-name" placeholder="e.g. Goblet Squat" /></label>' +
+      '<label class="field"><span>Muscle group</span><select id="nx-muscle">' +
+        MUSCLES.map(function (m) { return '<option>' + m + '</option>'; }).join('') + '</select></label>' +
+      '<label class="field"><span>Equipment</span><select id="nx-equip">' +
+        EQUIP.map(function (m) { return '<option>' + m + '</option>'; }).join('') + '</select></label>' +
+      '<label class="field"><span>Description (optional)</span><textarea id="nx-desc" rows="3"></textarea></label>' +
+      '<div id="nx-msg" class="msg"></div>' +
+      '<div class="stack"><button class="btn" id="nx-save">Save</button>' +
+      '<button class="btn secondary" id="nx-cancel">Cancel</button></div>');
+    sheet.querySelector('#nx-cancel').addEventListener('click', closeSheet);
+    sheet.querySelector('#nx-save').addEventListener('click', function () {
+      var name = sheet.querySelector('#nx-name').value.trim();
+      if (!name) { var m = sheet.querySelector('#nx-msg'); m.className = 'msg show err'; m.textContent = 'Name is required.'; return; }
+      sb.from('exercises').insert({
+        user_id: state.user.id, name: name,
+        muscle_group: sheet.querySelector('#nx-muscle').value,
+        equipment: sheet.querySelector('#nx-equip').value,
+        description: sheet.querySelector('#nx-desc').value.trim() || null
+      }).then(function (r) {
+        if (r.error) { var m = sheet.querySelector('#nx-msg'); m.className = 'msg show err'; m.textContent = r.error.message; return; }
+        closeSheet(); loadExercises().then(renderExercises);
+      });
+    });
+  }
+
+  function pickExercise(cb) {
+    var html = '<h2>Pick an exercise</h2>' +
+      '<input id="pk-search" type="search" placeholder="Search…" style="margin-bottom:14px" />' +
+      '<div id="pk-list"></div>';
+    var sheet = openSheet(html);
+    function paint() {
+      var q = (sheet.querySelector('#pk-search').value || '').toLowerCase().trim();
+      var list = state.exercises.filter(function (e) { return !q || e.name.toLowerCase().indexOf(q) !== -1; });
+      sheet.querySelector('#pk-list').innerHTML = list.map(function (e) {
+        return '<button class="card tap" data-pick="' + e.id + '"><div style="font-weight:650">' + esc(e.name) + '</div>' +
+          '<div class="muted" style="font-size:13px">' + esc(e.muscle_group || '') + ' · ' + esc(e.equipment || '') + '</div></button>';
+      }).join('') || '<div class="empty">No matches.</div>';
+      sheet.querySelectorAll('[data-pick]').forEach(function (b) {
+        b.addEventListener('click', function () {
+          var ex = state.exById[+b.getAttribute('data-pick')];
+          closeSheet(); cb(ex);
+        });
+      });
+    }
+    sheet.querySelector('#pk-search').addEventListener('input', paint);
+    paint();
+  }
+
+  /* ----------------------------------------------------------------------- *
+   * Template editor
+   * ----------------------------------------------------------------------- */
+  var PHASES = ['', 'Month 1', 'Month 2'];
+  function openTemplateEditor(templateId) {
+    var loader = templateId ? getTemplate(templateId) : Promise.resolve({ name: '', phase: '', template_exercises: [] });
+    loader.then(function (t) {
+      var items = (t.template_exercises || []).map(function (te) {
+        return { exercise_id: te.exercise_id, name: (state.exById[te.exercise_id] || {}).name || 'Exercise',
+          section: te.section || '', target_sets: te.target_sets || '3',
+          target_reps: te.target_reps || '10-15', target_rest: te.target_rest || '2-3 min' };
+      });
+      var draft = { id: templateId, name: t.name || '', phase: t.phase || '', items: items };
+      paintEditor(draft);
+    });
+  }
+  function paintEditor(draft) {
+    var html = '<h2>' + (draft.id ? 'Edit template' : 'New template') + '</h2>' +
+      '<label class="field"><span>Name</span><input id="te-name" value="' + esc(draft.name) + '" placeholder="e.g. Full Body Split" /></label>' +
+      '<label class="field"><span>Phase</span><select id="te-phase">' +
+        PHASES.map(function (p) { return '<option value="' + p + '"' + (draft.phase === p ? ' selected' : '') + '>' + (p || 'None') + '</option>'; }).join('') +
+      '</select></label>' +
+      '<div class="section-head" style="margin-top:6px">Exercises</div><div id="te-items"></div>' +
+      '<button class="btn ghost" id="te-add" style="width:100%;margin:6px 0 16px">+ Add exercise</button>' +
+      '<div id="te-msg" class="msg"></div>' +
+      '<div class="stack"><button class="btn" id="te-save">Save template</button>' +
+      (draft.id ? '<button class="btn danger" id="te-delete">Delete template</button>' : '') +
+      '<button class="btn secondary" id="te-cancel">Cancel</button></div>';
+    var sheet = openSheet(html);
+
+    function paintItems() {
+      var box = sheet.querySelector('#te-items');
+      if (!draft.items.length) { box.innerHTML = '<div class="muted" style="font-size:14px;padding:4px 2px 10px">No exercises yet.</div>'; return; }
+      box.innerHTML = draft.items.map(function (it, i) {
+        return '<div class="card" style="padding:12px"><div class="row" style="margin-bottom:8px">' +
+          '<div class="grow" style="font-weight:650">' + esc(it.name) + '</div>' +
+          '<button class="iconbtn" data-up="' + i + '" title="Up">↑</button>' +
+          '<button class="iconbtn" data-down="' + i + '" title="Down">↓</button>' +
+          '<button class="iconbtn" data-rm="' + i + '" title="Remove">✕</button></div>' +
+          '<div class="row" style="gap:8px">' +
+          '<input data-fi="section" data-i="' + i + '" placeholder="Section" value="' + esc(it.section) + '" style="flex:1.4" />' +
+          '<input data-fi="target_sets" data-i="' + i + '" placeholder="Sets" value="' + esc(it.target_sets) + '" />' +
+          '</div><div class="row" style="gap:8px;margin-top:8px">' +
+          '<input data-fi="target_reps" data-i="' + i + '" placeholder="Reps" value="' + esc(it.target_reps) + '" />' +
+          '<input data-fi="target_rest" data-i="' + i + '" placeholder="Rest" value="' + esc(it.target_rest) + '" />' +
+          '</div></div>';
+      }).join('');
+      box.querySelectorAll('[data-fi]').forEach(function (inp) {
+        inp.addEventListener('change', function () { draft.items[+inp.getAttribute('data-i')][inp.getAttribute('data-fi')] = inp.value; });
+      });
+      box.querySelectorAll('[data-rm]').forEach(function (b) {
+        b.addEventListener('click', function () { draft.items.splice(+b.getAttribute('data-rm'), 1); paintItems(); });
+      });
+      box.querySelectorAll('[data-up]').forEach(function (b) {
+        b.addEventListener('click', function () { var i = +b.getAttribute('data-up'); if (i > 0) { var t = draft.items[i - 1]; draft.items[i - 1] = draft.items[i]; draft.items[i] = t; paintItems(); } });
+      });
+      box.querySelectorAll('[data-down]').forEach(function (b) {
+        b.addEventListener('click', function () { var i = +b.getAttribute('data-down'); if (i < draft.items.length - 1) { var t = draft.items[i + 1]; draft.items[i + 1] = draft.items[i]; draft.items[i] = t; paintItems(); } });
+      });
+    }
+    paintItems();
+
+    sheet.querySelector('#te-name').addEventListener('change', function (e) { draft.name = e.target.value; });
+    sheet.querySelector('#te-phase').addEventListener('change', function (e) { draft.phase = e.target.value; });
+    sheet.querySelector('#te-cancel').addEventListener('click', closeSheet);
+    sheet.querySelector('#te-add').addEventListener('click', function () {
+      // re-sync field values before re-render
+      pickExercise(function (ex) {
+        draft.items.push({ exercise_id: ex.id, name: ex.name, section: '',
+          target_sets: '3', target_reps: '10-15', target_rest: '2-3 min' });
+        paintEditor(draft);
+      });
+    });
+    if (draft.id) sheet.querySelector('#te-delete').addEventListener('click', function () {
+      if (!confirm('Delete this template? Logged workouts are kept.')) return;
+      sb.from('templates').delete().eq('id', draft.id).then(function () { closeSheet(); renderTemplatesTab(); });
+    });
+    sheet.querySelector('#te-save').addEventListener('click', function () {
+      draft.name = sheet.querySelector('#te-name').value.trim();
+      if (!draft.name) { var m = sheet.querySelector('#te-msg'); m.className = 'msg show err'; m.textContent = 'Name is required.'; return; }
+      saveTemplate(draft).then(function () { closeSheet(); renderTemplatesTab(); });
+    });
+  }
+
+  function saveTemplate(draft) {
+    var phase = draft.phase || null;
+    var upsertTpl = draft.id
+      ? sb.from('templates').update({ name: draft.name, phase: phase }).eq('id', draft.id).then(function () { return draft.id; })
+      : sb.from('templates').insert({ user_id: state.user.id, name: draft.name, phase: phase })
+          .select('id').single().then(function (r) { return r.data.id; });
+    return upsertTpl.then(function (tid) {
+      return sb.from('template_exercises').delete().eq('template_id', tid).then(function () {
+        if (!draft.items.length) return;
+        var rows = draft.items.map(function (it, i) {
+          return { template_id: tid, exercise_id: it.exercise_id, user_id: state.user.id,
+            section: it.section || null, position: i + 1,
+            target_sets: it.target_sets || null, target_reps: it.target_reps || null, target_rest: it.target_rest || null };
+        });
+        return sb.from('template_exercises').insert(rows);
+      });
+    });
+  }
+
+  /* ----------------------------------------------------------------------- *
+   * Go
+   * ----------------------------------------------------------------------- */
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+  else boot();
 })();


### PR DESCRIPTION
Rebuilds `strength.html` from the simple v1 logger into the full Workout
Logger from the build guide, adapted to the Supabase + static stack.

**Schema** (already applied to the `strength-log` project): 5-table model +
`profiles`, `user_id` as `uuid → auth.users`, RLS on every table, 14 seed
exercises. Drops the empty v1 tables.

**App**: mobile-first SPA — bottom tabs (Workouts / History / Exercises);
full-screen active session with weight/rep steppers, inline last-time hints
+ PR cue, per-set autosave, resume-in-progress, optional rest timer; history
by month + read-only detail; per-exercise progress charts; exercise library
with custom exercises; template create/edit; lb/kg setting. Two starter
templates are created on first login.

Replaces v1 per the agreed plan. The checklist generator is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)