### PR TITLE
Workout Logger: in-app delete, sheet close buttons, labeled back

### DIFF
--- a/strength.html
+++ b/strength.html
@@ -173,8 +173,15 @@
   .modal-back { position: fixed; inset: 0; background: rgba(0,0,0,.4); z-index: 60; display: flex; align-items: flex-end;
     justify-content: center; }
   .sheet { background: var(--card); width: 100%; max-width: var(--maxw); border-radius: 22px 22px 0 0;
-    padding: 20px 18px calc(24px + var(--safe-b)); max-height: 90vh; overflow-y: auto; }
-  .sheet h2 { font-size: 20px; margin-bottom: 14px; }
+    padding: 20px 18px calc(24px + var(--safe-b)); max-height: 90vh; overflow-y: auto; position: relative; }
+  .sheet h2 { font-size: 20px; margin-bottom: 14px; padding-right: 40px; }
+  .sheet-close { position: absolute; top: 12px; right: 12px; width: 38px; height: 38px; border-radius: 50%;
+    background: var(--bg); color: var(--muted); font-size: 18px; display: flex; align-items: center; justify-content: center; z-index: 2; }
+  .sheet-close:active { background: var(--line); }
+
+  .backbtn { display: inline-flex; align-items: center; gap: 2px; height: 40px; padding: 0 14px 0 8px; flex: none;
+    border-radius: 999px; color: var(--accent); font-weight: 650; font-size: 16px; }
+  .backbtn:active { background: var(--line); }
 
   @media (prefers-reduced-motion: reduce) {
     * { transition: none !important; animation: none !important; }
@@ -249,7 +256,7 @@
 
 <section id="view-session" hidden>
   <div class="sessionhead">
-    <button class="iconbtn" id="session-back" title="Minimize">‹</button>
+    <button class="backbtn" id="session-back" title="Back to workouts">‹ Back</button>
     <div class="grow"><div class="ttl" id="session-title">Session</div><div class="sub" id="session-sub"></div></div>
     <button class="btn small" id="session-finish">Finish</button>
   </div>
@@ -258,7 +265,7 @@
 
 <section id="view-progress" hidden>
   <div class="sessionhead">
-    <button class="iconbtn" id="progress-back" title="Back">‹</button>
+    <button class="backbtn" id="progress-back" title="Back">‹ Back</button>
     <div class="grow"><div class="ttl" id="progress-title">Progress</div><div class="sub" id="progress-sub"></div></div>
   </div>
   <div class="screen" style="padding-top:14px" id="progress-body"></div>
@@ -266,7 +273,7 @@
 
 <section id="view-detail" hidden>
   <div class="sessionhead">
-    <button class="iconbtn" id="detail-back" title="Back">‹</button>
+    <button class="backbtn" id="detail-back" title="Back">‹ Back</button>
     <div class="grow"><div class="ttl" id="detail-title">Session</div><div class="sub" id="detail-sub"></div></div>
   </div>
   <div class="screen" style="padding-top:14px" id="detail-body"></div>

--- a/strength.js
+++ b/strength.js
@@ -708,7 +708,19 @@
             }).join('') + '</div>';
         });
         if (s.notes) html += '<div class="card"><div class="muted" style="font-size:13px;text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Notes</div>' + esc(s.notes) + '</div>';
-        body.innerHTML = html || '<div class="empty">No sets logged.</div>';
+        html = (html || '<div class="empty">No sets logged.</div>') +
+          '<button class="btn danger" id="detail-delete" style="margin-top:18px">Delete this workout</button>';
+        body.innerHTML = html;
+        var del = $('detail-delete');
+        del.addEventListener('click', function () {
+          if (!window.confirm('Delete this workout? This permanently removes the session and all its sets.')) return;
+          del.disabled = true; del.textContent = 'Deleting…';
+          sb.from('sessions').delete().eq('id', id).then(function (r) {
+            if (r.error) { del.disabled = false; del.textContent = 'Delete this workout'; alert('Could not delete: ' + r.error.message); return; }
+            overlay('view-detail', false);
+            renderHistory();
+          });
+        });
       });
   }
 
@@ -812,9 +824,11 @@
    * ----------------------------------------------------------------------- */
   function openSheet(html) {
     var root = $('modal-root');
-    root.innerHTML = '<div class="modal-back"><div class="sheet">' + html + '</div></div>';
+    root.innerHTML = '<div class="modal-back"><div class="sheet">' +
+      '<button class="sheet-close" aria-label="Close">✕</button>' + html + '</div></div>';
     var back = root.querySelector('.modal-back');
     back.addEventListener('click', function (e) { if (e.target === back) closeSheet(); });
+    root.querySelector('.sheet-close').addEventListener('click', closeSheet);
     return root.querySelector('.sheet');
   }
   function closeSheet() { $('modal-root').innerHTML = ''; }


### PR DESCRIPTION
- Delete a finished workout from its detail view (confirm; cascades sets)
- ✕ close button on every bottom-sheet popup (picker had none)
- Labeled '‹ Back' button on workout/progress/detail screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)